### PR TITLE
test: issue with global .asyncapi file getting overwritten while testing

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,9 @@ import * as fs from 'fs';
 import { SpecificationFile } from './hooks/validation';
 import { Context } from './hooks/context/models';
 
-export const CONTEXT_FILENAME = (process.env['NODE_ENV'] === "test")? ".test.asyncapi": ".asyncapi";
+const isTestEnv = (process.env['NODE_ENV'] === 'test') || (process.env['JEST_WORKER_ID'] !== undefined) || typeof jest !== 'undefined';
+
+export const CONTEXT_FILENAME = isTestEnv ? ".test.asyncapi" : ".asyncapi";
 
 export const CONTEXTFILE_PATH = path.resolve(os.homedir(), CONTEXT_FILENAME);
 
@@ -27,14 +29,14 @@ export class ContextTestingHelper {
 	}
 
 	createDummyContextFile() {
-		fs.writeFileSync(CONTEXTFILE_PATH, JSON.stringify(this._context), {encoding: 'utf-8'});
+		fs.writeFileSync(CONTEXTFILE_PATH, JSON.stringify(this._context), { encoding: 'utf-8' });
 	}
 
 	deleteDummyContextFile() {
-		if(fs.existsSync(CONTEXTFILE_PATH)) fs.unlinkSync(CONTEXTFILE_PATH);
+		if (fs.existsSync(CONTEXTFILE_PATH)) fs.unlinkSync(CONTEXTFILE_PATH);
 	}
 
-	getPath(key: string){
+	getPath(key: string) {
 		return this._context.store[key];
 	}
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,9 @@ import * as fs from 'fs';
 import { SpecificationFile } from './hooks/validation';
 import { Context } from './hooks/context/models';
 
-export const CONTEXTFILE_PATH = path.resolve(os.homedir(), '.asyncapi');
+export const CONTEXT_FILENAME = (process.env['NODE_ENV'] === "test")? ".test.asyncapi": ".asyncapi";
+
+export const CONTEXTFILE_PATH = path.resolve(os.homedir(), CONTEXT_FILENAME);
 
 export class ContextTestingHelper {
 	private _context: Context;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Running integration testing was overwriting the global `.asyncapi` file and it was quite annoying while developing. 
- We basically check if the `NODE_ENV` is `test`, and use `.test.asyncapi` file to do all the testing related operations. 

**Related issue(s)**
Fixes #23 