### PR TITLE
feat: created hook to load spec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Commands
 Examples
   $ asyncapi context add dummy ./asyncapi.yml
   $ asyncapi validate --context=dummy
-  $ asyncapi validate
   $ asyncapi validate --file=./asyncapi.yml
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Commands
    Options
      -c --context  context-name saved in the store
      -w --watch Enable watchMode (not implemented yet)
+     -f --file File path of the specification file
   
   context
     current show the current set context
@@ -35,7 +36,9 @@ Commands
 
 Examples
   $ asyncapi context add dummy ./asyncapi.yml
-	  $ asyncapi validate --context=dummy
+  $ asyncapi validate --context=dummy
+  $ asyncapi validate
+  $ asyncapi validate --file=./asyncapi.yml
 ```
 
 > For now --context flag is requried to run validate command

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,12 +31,12 @@
 			}
 		},
 		"@asyncapi/parser": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-1.6.0.tgz",
-			"integrity": "sha512-uLLoDn0Enisp7JgZV6TdK7AfbQF0dxS4j68XGjoslTew/OGfAatchpuP5ARMcxqnygYyhtEFcOd/qzKbmZy2zA==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-1.7.0.tgz",
+			"integrity": "sha512-ULL6k+s1zzeLLCUH2l0nsTxtCdiUdnAkMROhXD5XnEAIN+3M3tYO39w9HcbzKHngxFFhr0MsHOrGpw61rcxIsw==",
 			"requires": {
 				"@apidevtools/json-schema-ref-parser": "^9.0.6",
-				"@asyncapi/specs": "^2.7.8",
+				"@asyncapi/specs": "2.8.0",
 				"@fmvilas/pseudo-yaml-ast": "^0.3.1",
 				"ajv": "^6.10.1",
 				"js-yaml": "^3.13.1",
@@ -47,9 +47,9 @@
 			}
 		},
 		"@asyncapi/specs": {
-			"version": "2.7.8",
-			"resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.7.8.tgz",
-			"integrity": "sha512-GvyUo8rKAY25XdhM2dYqv4yf6gzgiNRazLxbeQfeD5oXu4aEs/rkpcgHPeb3ckA6xXiyzdBnpVYhJOcPvgr46g=="
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.8.0.tgz",
+			"integrity": "sha512-ZVyr1L0Le8Z0mvr2BPriszaDu53rZxevjqVCXt3PqJMPJuiiGMVhkslmclj474nBK0ckygSRe8jAd4smm9XOrg=="
 		},
 		"@babel/code-frame": {
 			"version": "7.12.13",
@@ -1094,9 +1094,9 @@
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
+			"version": "7.0.8",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
+			"integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg=="
 		},
 		"@types/minimist": {
 			"version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"dist"
 	],
 	"dependencies": {
-		"@asyncapi/parser": "^1.6.0",
+		"@asyncapi/parser": "^1.7.0",
 		"ink": "^3.0.8",
 		"meow": "^9.0.0",
 		"react": "^17.0.1",

--- a/src/CliModels.ts
+++ b/src/CliModels.ts
@@ -4,8 +4,9 @@ export type HelpMessage = string;
 export type Arguments = string[];
 
 export interface Options {
-  context: string,
-  watch: boolean
+  context?: string,
+  watch: boolean,
+  file?: string
 }
 
 export class CliInput {

--- a/src/CliModels.ts
+++ b/src/CliModels.ts
@@ -35,8 +35,8 @@ export class CliInput {
 
   static createFromMeow(meowOutput: any): CliInput {
     const [command, ...args] = meowOutput.input;
-    const { context, watch } = meowOutput.flags;
-    return new CliInput(command || 'help', { context, watch }, args);
+    const { context, watch, file } = meowOutput.flags;
+    return new CliInput(command || 'help', { context, watch, file }, args);
   }
 
   static createSubCommand(cliInput: CliInput): CliInput {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ const cli = meow(`
 			Options
 				-c --context  context-name saved in the store
 				-w --watch Enable watchMode (not implemented yet)
-				-f --file file path of the specification file
+				-f --file File path of the specification file
 		context
 			current  show the current set context
 			list     show the list of all stored context
@@ -25,6 +25,7 @@ const cli = meow(`
 	Examples
 	  $ asyncapi context add dummy ./asyncapi.yml
       $ asyncapi validate --context=dummy
+	  $ asyncapi validate --file=./asyncapi.yml
 `, {
 	flags: {
 		context: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,9 +23,9 @@ const cli = meow(`
 			add <context-name> <filepath> add/update new context
 
 	Examples
-	  $ asyncapi context add dummy ./asyncapi.yml
-      $ asyncapi validate --context=dummy
-	  $ asyncapi validate --file=./asyncapi.yml
+		$ asyncapi context add dummy ./asyncapi.yml
+		$ asyncapi validate --context=dummy
+		$ asyncapi validate --file=./asyncapi.yml
 `, {
 	flags: {
 		context: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ const cli = meow(`
 			Options
 				-c --context  context-name saved in the store
 				-w --watch Enable watchMode (not implemented yet)
+				-f --file file path of the specification file
 		context
 			current  show the current set context
 			list     show the list of all stored context
@@ -23,7 +24,7 @@ const cli = meow(`
 
 	Examples
 	  $ asyncapi context add dummy ./asyncapi.yml
-	  $ asyncapi validate --context=dummy
+      $ asyncapi validate --context=dummy
 `, {
 	flags: {
 		context: {
@@ -36,6 +37,11 @@ const cli = meow(`
 			type: 'boolean',
 			isRequired: false,
 			default: false
+		},
+		file: {
+			alias: 'f',
+			type: 'string',
+			isRequired: false
 		}
 	}
 });

--- a/src/components/Context/context.spec.tsx
+++ b/src/components/Context/context.spec.tsx
@@ -26,7 +26,8 @@ describe('rendering current context', () => {
 	test('showing error if now current context is found', () => {
 		testing.deleteDummyContextFile();
 		let { lastFrame } = render(<ShowCurrentContext />);
-		expect(lastFrame()).toMatch('No contexts saved yet.');
+		let message = lastFrame();
+		expect(message).toMatch('No contexts saved yet.');
 	})
 
 	test('showing current context ', () => {

--- a/src/components/Validate/Validate.tsx
+++ b/src/components/Validate/Validate.tsx
@@ -12,7 +12,7 @@ interface ValidateInput {
 const Validate: FunctionComponent<ValidateInput> = ({ options }) => {
 	let { specFile, error } = useSpecfile({ context: options.context, file: options.file });
 	if (error) {
-		if (error) return <Text color="red">{error.message}</Text>
+		return <Text color="red">{error.message}</Text>
 	}
 
 	if (!specFile) {

--- a/src/components/Validate/Validate.tsx
+++ b/src/components/Validate/Validate.tsx
@@ -3,20 +3,24 @@ import { Newline, Text } from 'ink';
 import { Options } from "../../CliModels";
 import { SpecificationFile, useValidate } from "../../hooks/validation";
 import { UseValidateResponse } from "../../hooks/validation/models";
-import { useContextFile } from '../../hooks/context';
+import { useSpecfile } from '../../hooks/context';
 
 interface ValidateInput {
 	options: Options,
 }
 
 const Validate: FunctionComponent<ValidateInput> = ({ options }) => {
-	let { response, error } = useContextFile().getContext(options.context);
-	if (error || !response) {
+	let { specFile, error } = useSpecfile({context: options.context, })
+	if (error) {
 		if(error) return <Text color="red">{error.message}</Text>
 	}
 
+	if(!specFile){
+		return <Text></Text>
+	}
+
 	const validationInput = {
-		file: new SpecificationFile(response.getSpecificationName()),
+		file: new SpecificationFile(specFile.getSpecificationName()),
 		watchMode: options.watch,
 	};
 

--- a/src/components/Validate/Validate.tsx
+++ b/src/components/Validate/Validate.tsx
@@ -10,13 +10,13 @@ interface ValidateInput {
 }
 
 const Validate: FunctionComponent<ValidateInput> = ({ options }) => {
-	let { specFile, error } = useSpecfile({context: options.context, file: options.file});
+	let { specFile, error } = useSpecfile({ context: options.context, file: options.file });
 	if (error) {
-		if(error) return <Text color="red">{error.message}</Text>
+		if (error) return <Text color="red">{error.message}</Text>
 	}
 
-	if(!specFile){
-		return <Text></Text>
+	if (!specFile) {
+		return <Text />
 	}
 
 	const validationInput = {

--- a/src/components/Validate/Validate.tsx
+++ b/src/components/Validate/Validate.tsx
@@ -10,7 +10,7 @@ interface ValidateInput {
 }
 
 const Validate: FunctionComponent<ValidateInput> = ({ options }) => {
-	let { specFile, error } = useSpecfile({context: options.context, })
+	let { specFile, error } = useSpecfile({context: options.context, file: options.file});
 	if (error) {
 		if(error) return <Text color="red">{error.message}</Text>
 	}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,4 +39,12 @@ export class ContextTestingHelper {
 	getPath(key: string) {
 		return this._context.store[key];
 	}
+
+	createSpecFileAtWorkingDir(){
+		fs.writeFileSync(path.resolve(process.cwd(), 'asyncapi.yml'), '');
+	}
+
+	deleteSpecFileAtWorkingDir(){
+		if(fs.existsSync(path.resolve(process.cwd(), 'asyncapi.yml'))) fs.unlinkSync(path.resolve(process.cwd(), 'asyncapi.yml'));
+	}
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,11 +40,11 @@ export class ContextTestingHelper {
 		return this._context.store[key];
 	}
 
-	createSpecFileAtWorkingDir(){
-		fs.writeFileSync(path.resolve(process.cwd(), 'asyncapi.yml'), '');
+	createSpecFileAtWorkingDir() {
+		if (!fs.existsSync(path.resolve(process.cwd(), 'asyncapi.yml'))) fs.writeFileSync(path.resolve(process.cwd(), 'asyncapi.yml'), '');
 	}
 
-	deleteSpecFileAtWorkingDir(){
-		if(fs.existsSync(path.resolve(process.cwd(), 'asyncapi.yml'))) fs.unlinkSync(path.resolve(process.cwd(), 'asyncapi.yml'));
+	deleteSpecFileAtWorkingDir() {
+		if (fs.existsSync(path.resolve(process.cwd(), 'asyncapi.yml'))) fs.unlinkSync(path.resolve(process.cwd(), 'asyncapi.yml'));
 	}
 }

--- a/src/hooks/context/contextService.spec.ts
+++ b/src/hooks/context/contextService.spec.ts
@@ -55,6 +55,7 @@ describe('ContextService.autoDetect', () => {
 	const contextService = new ContextService();
 
 	test("Should return undefined when does not detects anyfile", () => {
+		testing.deleteSpecFileAtWorkingDir();
 		expect(contextService.autoDetectSpecFile()).toBeUndefined();
 	});
 

--- a/src/hooks/context/hook.spec.ts
+++ b/src/hooks/context/hook.spec.ts
@@ -150,12 +150,11 @@ describe('useSpecFile should ', () => {
 		expect(error).toBeUndefined();
 		expect(specFile).toBeDefined();
 	});
-	it.skip('Load spec file from working directory', () => {
-		testingVariables.createSpecFileAtWorkingDir();
+	
+	it('Throw error when nothing found', () => {
+		testingVariables.deleteDummyContextFile()
 		testingVariables.deleteDummyContextFile();
-		const { specFile } = useSpecfile({});
-		expect(specFile).toBeDefined();
-
-		testingVariables.deleteSpecFileAtWorkingDir();
+		const { error } = useSpecfile({});
+		expect(error).toBeDefined();
 	});
 })

--- a/src/hooks/context/hook.spec.ts
+++ b/src/hooks/context/hook.spec.ts
@@ -1,4 +1,4 @@
-import { useContextFile } from './hooks';
+import { useContextFile, useSpecfile } from './hooks';
 import { ContextFileNotFoundError, KeyNotFoundError, ContextNotFoundError } from './models';
 import { ContextTestingHelper } from '../../constants';
 import { SpecificationFile } from '../validation';
@@ -129,5 +129,33 @@ describe('useContextFile().getContext', () => {
 		let { response, error } = useContextFile().getContext('home');
 		expect(error).toBeUndefined();
 		expect(response instanceof SpecificationFile).toBeTruthy();
+	});
+})
+
+describe('useSpecFile should ', () => {
+	it('Load spec file from --file flag', () => {
+		const { specFile, error } = useSpecfile({ file: './test/specification.yml' });
+		expect(error).toBeUndefined();
+		expect(specFile instanceof SpecificationFile).toBeTruthy();
+	});
+	it('Load spec file from --context flag', () => {
+		testingVariables.createDummyContextFile();
+		const { specFile, error } = useSpecfile({ context: 'home' });
+		expect(error).toBeUndefined();
+		expect(specFile instanceof SpecificationFile).toBeTruthy();
+	});
+	it('Load spec file from current context', () => {
+		testingVariables.createDummyContextFile();
+		const { specFile, error } = useSpecfile({});
+		expect(error).toBeUndefined();
+		expect(specFile).toBeDefined();
+	});
+	it.skip('Load spec file from working directory', () => {
+		testingVariables.createSpecFileAtWorkingDir();
+		testingVariables.deleteDummyContextFile();
+		const { specFile } = useSpecfile({});
+		expect(specFile).toBeDefined();
+
+		testingVariables.deleteSpecFileAtWorkingDir();
 	});
 })

--- a/src/hooks/context/hooks.tsx
+++ b/src/hooks/context/hooks.tsx
@@ -15,8 +15,8 @@ export const useContextFile = () => {
 	return {
 		list: (): Result => {
 			try {
-				let ctx: Context = contextService.loadContextFile();
-				let response = Object.keys(ctx.store).map(c => ({ key: c, path: ctx.store[c] }));
+				const ctx: Context = contextService.loadContextFile();
+				const response = Object.keys(ctx.store).map(c => ({ key: c, path: ctx.store[c] }));
 				return { response };
 			} catch (error) {
 				return { error };
@@ -24,9 +24,9 @@ export const useContextFile = () => {
 		},
 		current: (): Result => {
 			try {
-				let ctx: Context = contextService.loadContextFile();
+				const ctx: Context = contextService.loadContextFile();
 				if (!ctx.current) throw new MissingCurrentContextError();
-				let response = { key: ctx.current, path: ctx.store[ctx.current] };
+				const response = { key: ctx.current, path: ctx.store[ctx.current] };
 				return { response };
 			} catch (error) {
 				return { error };
@@ -34,17 +34,17 @@ export const useContextFile = () => {
 		},
 		addContext: (key: string, specFile: SpecificationFile): Result => {
 			try {
-				let ctx = contextService.loadContextFile();
-				let updatedContext = contextService.addContext(ctx, key, specFile);
+				const ctx = contextService.loadContextFile();
+				const updatedContext = contextService.addContext(ctx, key, specFile);
 				contextService.save(updatedContext);
-				let response = "New context added";
+				const response = "New context added";
 				return { response };
 			} catch (error) {
 				if (error instanceof ContextFileNotFoundError) {
-					let context: Context = { current: '', store: {} };
-					let newContext = contextService.addContext(context, key, specFile);
+					const context: Context = { current: '', store: {} };
+					const newContext = contextService.addContext(context, key, specFile);
 					contextService.save(contextService.updateCurrent(newContext, key));
-					let response = "New context added";
+					const response = "New context added";
 					return { response };
 				}
 				return { error }
@@ -52,10 +52,10 @@ export const useContextFile = () => {
 		},
 		setCurrent: (key: string): Result => {
 			try {
-				let ctx = contextService.loadContextFile();
-				let updateCurrent = contextService.updateCurrent(ctx, key);
+				const ctx = contextService.loadContextFile();
+				const updateCurrent = contextService.updateCurrent(ctx, key);
 				contextService.save(updateCurrent);
-				let response = { key: updateCurrent.current, path: updateCurrent.store[updateCurrent.current] };
+				const response = { key: updateCurrent.current, path: updateCurrent.store[updateCurrent.current] };
 				return { response };
 			} catch (error) {
 				return { error };
@@ -63,12 +63,12 @@ export const useContextFile = () => {
 		},
 		deleteContext: (key: string): Result => {
 			try {
-				let ctx = contextService.loadContextFile();
+				const ctx = contextService.loadContextFile();
 				if (Object.keys(ctx.store).length === 1) {
 					contextService.deleteContextFile();
 					return { response: "context deleted successfully" };
 				}
-				let updatedContext = contextService.deleteContext(ctx, key);
+				const updatedContext = contextService.deleteContext(ctx, key);
 				contextService.save(updatedContext);
 				const response = "context deleted successfully";
 				return { response }
@@ -79,12 +79,12 @@ export const useContextFile = () => {
 		loadSpecFile: (): Result => {
 			try {
 				let response: SpecificationFile;
-				let autoDetectedSpecFile = contextService.autoDetectSpecFile();
+				const autoDetectedSpecFile = contextService.autoDetectSpecFile();
 				if (autoDetectedSpecFile) {
 					response = new SpecificationFile(autoDetectedSpecFile);
 					return { response };
 				}
-				let context = contextService.loadContextFile();
+				const context = contextService.loadContextFile();
 				//@ts-ignore
 				response = new SpecificationFile(context.store[context.current]);
 				return { response };
@@ -95,10 +95,10 @@ export const useContextFile = () => {
 		},
 		getContext: (key: string): Result => {
 			try {
-				let ctx = contextService.loadContextFile();
+				const ctx = contextService.loadContextFile();
 				if (!ctx.store[key]) throw new ContextNotFoundError();
 				//@ts-ignore
-				let response = new SpecificationFile(ctx.store[key]);
+				const response = new SpecificationFile(ctx.store[key]);
 				return { response }
 			} catch (error) {
 				return { error };
@@ -121,31 +121,34 @@ export const useSpecfile = (flags: useSpecFileInput): useSpecFileOutput => {
 	const contextService: ContextService = container.resolve(ContextService);
 
 	try {
-		let ctx: Context = contextService.loadContextFile();
 		if (flags.file) {
-			let specFile: SpecificationFile = new SpecificationFile(flags.file);
+			const specFile: SpecificationFile = new SpecificationFile(flags.file);
 			if (specFile.isNotValid()) throw new Error("Invalid spec path");
 			return { specFile };
 		}
 
+
+		let ctx: Context = contextService.loadContextFile();
+
 		if (flags.context) {
-			if (!ctx.store[flags.context]) throw new ContextNotFoundError();
-			//@ts-ignore
-			const specFile = new SpecificationFile(ctx.store[flags.context]);
+			const ctxFile = ctx.store[flags.context];
+			if (!ctxFile) throw new ContextNotFoundError();
+			const specFile = new SpecificationFile(ctxFile);
 			return { specFile };
 		}
 
 		if (ctx.current) {
-			//@ts-ignore
-			let specFile = new SpecificationFile(ctx.store[ctx.current]);
+			const currentFile = ctx.store[ctx.current];
+			if (!currentFile) throw new MissingCurrentContextError();
+			const specFile = new SpecificationFile(currentFile);
 			return { specFile };
 		}
 
-		let autoDetectedSpecPath = contextService.autoDetectSpecFile();
+		const autoDetectedSpecPath = contextService.autoDetectSpecFile();
 
 		if (typeof autoDetectedSpecPath === 'undefined') throw new Error("No spec path found in your working directory, please use flags or store a context");
 
-		let specFile = new SpecificationFile(autoDetectedSpecPath);
+		const specFile = new SpecificationFile(autoDetectedSpecPath);
 
 		return { specFile };
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- As of now we are storing context and we access any context we are using the `--context` flag to load from the contexts. 
- This PR will complete the context store use case and intelligently figure out which specification file to load.  
- aims to autodetect specification file path `asyncapi validate`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #20 