### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# This file provides an overview of code owners in this repository.
+
+# Each line is a file pattern followed by one or more owners.
+# The last matching pattern has the most precedence.
+# For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
+
+# These are the default owners for the whole content of the "@asyncapi/asyncapi-react" repository. The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
+* @jotamusik @Souvikns @magicmatatjahu @derberg @github-actions[bot]


### PR DESCRIPTION
**Description**

- This PR adds a CODEOWNERS file and I suggest that after we merge and change settings to make it required for minimum 1 codeowners to approve any PR but of course we should always try to have 2 👀 on a PR if possible. The reason why these people are on the list:
  - @jotamusik is added of course because the whole project and its setup is done by him. 
  - @Souvikns is added because of his strong involvement in the project for several weeks now and proved to understand of the project structure, goal and codebase
  - @magicmatatjahu and me because we know the project well through review/approval process already and can easily be involved in maintenance
  - bot - because bot is doing lots of work that humans do not want to do, and bot is coolio

---
Please read what it means to be a committer aka CODEOWNER of the project https://github.com/asyncapi/.github/blob/master/CHARTER.md#3-committers-and-contributors

Please read that as a committer you become also a TSC member but you can also reject and clearly say that your focus is only this specific project -> https://github.com/asyncapi/.github/blob/master/CHARTER.md#2-technical-steering-committee (`Committers are the voting members of the TSC and must be listed in the VOTERS file within the Project’s code repository. The TSC may choose an alternative approach for determining the voting members of the TSC, and any such alternative approach will be documented in the Project’s GOVERNANCE file`). We do not have this set yet, lots of automation is needed in place to setup TSC, but technically you are becoming a member of it

---

@jotamusik @Souvikns @magicmatatjahu please have a look