### PR TITLE
refactor: updated and decoupled contextService logic

### DIFF
--- a/src/config/context/index.ts
+++ b/src/config/context/index.ts
@@ -1,0 +1,2 @@
+export * from './model';
+export * from './service';

--- a/src/config/context/model.spec.ts
+++ b/src/config/context/model.spec.ts
@@ -1,0 +1,25 @@
+import { Context, ContextAllocator } from './model';
+import { CONTEXTFILE_PATH, ContextTestingHelper } from '../../constants';
+
+const testingHelper = new ContextTestingHelper();
+
+const contextAllocator = new ContextAllocator();
+
+describe('ContextAllocator should ', () => {
+  test('have test contextFile path', () => {
+    expect(contextAllocator.contextFilePath).toMatch(CONTEXTFILE_PATH);
+  });
+
+  test('load context from test env path if present', () => {
+    testingHelper.createDummyContextFile();
+    const ctx = contextAllocator.load();
+    expect(ctx).toBeDefined();
+    expect(ctx instanceof Context).toBeTruthy();
+  });
+
+  test('return undefined if context file not present in root dir', () => {
+    testingHelper.deleteDummyContextFile();
+    expect(contextAllocator.load()).toBeUndefined();
+  });
+});
+

--- a/src/config/context/model.ts
+++ b/src/config/context/model.ts
@@ -1,4 +1,4 @@
-import { injectable, registry, } from 'tsyringe';
+import { injectable } from 'tsyringe';
 import fs from 'fs';
 import { CONTEXTFILE_PATH } from '../../constants';
 
@@ -30,12 +30,6 @@ export interface IContextAllocator {
 }
 
 @injectable()
-@registry([
-  {
-    token: 'IContextAllocator',
-    useToken: ContextAllocator
-  }
-])
 export class ContextAllocator implements IContextAllocator {
   contextFilePath = CONTEXTFILE_PATH;
   load(): Context | undefined {
@@ -48,7 +42,10 @@ export class ContextAllocator implements IContextAllocator {
 
   save(context: Context) {
     try {
-      fs.writeFileSync(this.contextFilePath, JSON.stringify(context), { encoding: 'utf8' });
+      fs.writeFileSync(this.contextFilePath, JSON.stringify({
+        current: context.current,
+        store: context.store
+      }), { encoding: 'utf8' });
       return true;
     } catch (error) {
       return false;

--- a/src/config/context/model.ts
+++ b/src/config/context/model.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-/* eslint-disable no-console */
 import { injectable } from 'tsyringe';
 import fs from 'fs';
 import { CONTEXTFILE_PATH } from '../../constants';
@@ -38,6 +36,7 @@ export class ContextAllocator implements IContextAllocator {
     try {
       return new Context(JSON.parse(fs.readFileSync(this.contextFilePath, 'utf8')) as IContext);
     } catch (error) {
+      console.warn(error);// eslint-disable-line no-undef, no-console
       return undefined;
     }
   }
@@ -50,7 +49,7 @@ export class ContextAllocator implements IContextAllocator {
       }), { encoding: 'utf8' });
       return context;
     } catch (error) {
-      console.warn(error);
+      console.warn(error);// eslint-disable-line no-undef, no-console
       return undefined;
     }
   }

--- a/src/config/context/model.ts
+++ b/src/config/context/model.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+/* eslint-disable no-console */
 import { injectable } from 'tsyringe';
 import fs from 'fs';
 import { CONTEXTFILE_PATH } from '../../constants';
@@ -48,6 +50,7 @@ export class ContextAllocator implements IContextAllocator {
       }), { encoding: 'utf8' });
       return context;
     } catch (error) {
+      console.warn(error);
       return undefined;
     }
   }

--- a/src/config/context/model.ts
+++ b/src/config/context/model.ts
@@ -1,0 +1,58 @@
+import { injectable, registry, } from 'tsyringe';
+import fs from 'fs';
+import { CONTEXTFILE_PATH } from '../../constants';
+
+export interface IContext {
+  readonly current?: string,
+  readonly store: {
+    [name: string]: string
+  }
+}
+
+export class Context implements IContext {
+  current?: string | undefined;
+  store: { [name: string]: string; };
+
+  constructor(ctx: IContext) {
+    this.current = ctx.current;
+    this.store = ctx.store;
+  }
+
+  getContext(contextName: string) {
+    return this.store[contextName as string];
+  }
+}
+
+export interface IContextAllocator {
+  contextFilePath?: string
+  load: () => Context | undefined
+  save: (context: Context) => boolean
+}
+
+@injectable()
+@registry([
+  {
+    token: 'IContextAllocator',
+    useToken: ContextAllocator
+  }
+])
+export class ContextAllocator implements IContextAllocator {
+  contextFilePath = CONTEXTFILE_PATH;
+  load(): Context | undefined {
+    try {
+      return new Context(JSON.parse(fs.readFileSync(this.contextFilePath, 'utf8')) as IContext);
+    } catch (error) {
+      return undefined;
+    }
+  }
+
+  save(context: Context) {
+    try {
+      fs.writeFileSync(this.contextFilePath, JSON.stringify(context), { encoding: 'utf8' });
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+}
+

--- a/src/config/context/model.ts
+++ b/src/config/context/model.ts
@@ -26,7 +26,7 @@ export class Context implements IContext {
 export interface IContextAllocator {
   contextFilePath?: string
   load: () => Context | undefined
-  save: (context: Context) => boolean
+  save: (context: Context) => Context | undefined
 }
 
 @injectable()
@@ -46,9 +46,9 @@ export class ContextAllocator implements IContextAllocator {
         current: context.current,
         store: context.store
       }), { encoding: 'utf8' });
-      return true;
+      return context;
     } catch (error) {
-      return false;
+      return undefined;
     }
   }
 }

--- a/src/config/context/service.spec.ts
+++ b/src/config/context/service.spec.ts
@@ -8,7 +8,7 @@ class MockNegativeContextAllocator implements IContextAllocator {
   }
 
   save(_context: Context) {
-    return true;
+    return undefined;
   }
 }
 
@@ -24,7 +24,7 @@ class MockPositiveContextAllocator implements IContextAllocator {
   }
 
   save(context: Context) {
-    return context instanceof Context;
+    return context;
   }
 }
 

--- a/src/config/context/service.spec.ts
+++ b/src/config/context/service.spec.ts
@@ -1,0 +1,71 @@
+import { ContextService } from './service';
+import { Context, IContextAllocator } from './model';
+
+class MockNegativeContextAllocator implements IContextAllocator {
+  contextFilePath?: string | undefined;
+  load() {
+    return undefined;
+  }
+
+  save(_context: Context) {
+    return true;
+  }
+}
+
+class MockPositiveContextAllocator implements IContextAllocator {
+  load() {
+    return new Context({
+      current: 'test',
+      store: {
+        test: './test/specification.yml',
+        check: './test/specfication.yml'
+      }
+    });
+  }
+
+  save(context: Context) {
+    return context instanceof Context;
+  }
+}
+
+describe('ContextService should', () => {
+  test('load undefined context', () => {
+    const contextService = new ContextService(new MockNegativeContextAllocator());
+    expect(contextService.context).toBeUndefined();
+  });
+});
+
+let ctxService: ContextService;
+
+describe('ContextService should', () => {
+  beforeEach(() => {
+    ctxService = new ContextService(new MockPositiveContextAllocator());
+  });
+
+  test('load context when available', () => {
+    const ctx = ctxService.context;
+    expect(ctx).toBeDefined();
+  });
+
+  test('successfully save context', () => {
+    expect(ctxService.addContext('home', 'path')).toBeTruthy();
+  });
+
+  test('successfully delete context', () => {
+    const res = ctxService.deleteContext('test');
+    expect(res).toBeTruthy();
+    expect(ctxService.context?.getContext('test')).toBeUndefined();
+  });
+
+  test('return false when context not find to delete', () => {
+    expect(ctxService.deleteContext('home')).toBeFalsy();
+  });
+
+  test('update the current context if present', () => {
+    expect(ctxService.updateCurrent('check')).toBeTruthy();
+  });
+
+  test('return false if context is not present', () => {
+    expect(ctxService.updateCurrent('home')).toBeFalsy();
+  });
+});

--- a/src/config/context/service.ts
+++ b/src/config/context/service.ts
@@ -14,7 +14,7 @@ export class ContextService {
     return this._context;
   }
 
-  addContext(contextName: string, filePath: string): boolean {
+  addContext(contextName: string, filePath: string): Context | undefined {
     if (this._context) {
       this._context.store[contextName as string] = filePath;
       return this.contextAllocator.save(this._context);
@@ -23,21 +23,21 @@ export class ContextService {
     return this.contextAllocator.save(this._context);
   }
 
-  deleteContext(contextName: string) {
+  deleteContext(contextName: string): Context | undefined {
     if (this._context && this._context.store[contextName as string]) {
       if (this._context.current === contextName) { delete this._context.current; }
       delete this._context.store[contextName as string];
       return this.contextAllocator.save(this._context);
     }
-    return false;
+    return undefined;
   }
 
-  updateCurrent(contextName: string) {
+  updateCurrent(contextName: string): Context | undefined {
     if (this._context && this._context.getContext(contextName)) {
       this._context.current = contextName;
       return this.contextAllocator.save(this._context);
     }
-    return false;
+    return undefined;
   }
 
   static instantiate() {

--- a/src/config/context/service.ts
+++ b/src/config/context/service.ts
@@ -1,11 +1,11 @@
-import { Context, IContextAllocator, IContext } from './model';
+import { Context, IContextAllocator, IContext, ContextAllocator } from './model';
 import { injectable, inject, container } from 'tsyringe';
 
 @injectable()
 export class ContextService {
   private _context: Context | undefined
   constructor(
-    @inject('IContextAllocator') private contextAllocator: IContextAllocator
+    @inject(ContextAllocator) private contextAllocator: IContextAllocator
   ) {
     this._context = this.contextAllocator.load();
   }

--- a/src/config/context/service.ts
+++ b/src/config/context/service.ts
@@ -1,0 +1,47 @@
+import { Context, IContextAllocator } from './model';
+import { injectable, inject, container } from 'tsyringe';
+
+@injectable()
+export class ContextService {
+  private _context: Context | undefined
+  constructor(
+    @inject('IContextAllocator') private contextAllocator: IContextAllocator
+  ) {
+    this._context = this.contextAllocator.load();
+  }
+
+  get context() {
+    return this._context;
+  }
+
+  addContext(contextName: string, filePath: string): boolean {
+    if (this._context) {
+      this._context.store[contextName as string] = filePath;
+      return this.contextAllocator.save(this._context);
+    }
+    return false;
+  }
+
+  deleteContext(contextName: string) {
+    if (this._context && this._context.store[contextName as string]) {
+      delete this._context.store[contextName as string];
+      return this.contextAllocator.save(this._context);
+    }
+    return false;
+  }
+
+  updateCurrent(contextName: string) {
+    if (this._context && this._context.getContext(contextName)) {
+      this._context.current = contextName;
+      if (this.contextAllocator.save) {
+        this.contextAllocator.save(this._context);
+      }
+      return this.contextAllocator.save(this._context);
+    }
+    return false;
+  }
+
+  static instantiate() {
+    return container.resolve(ContextService);
+  }
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This is the start of the process to [move the context commands under config](https://github.com/asyncapi/cli/issues/37#issuecomment-908137433). In this PR I have focused on updating the `contextService` because of the issue discussed [here](https://github.com/asyncapi/cli/issues/38#issuecomment-912377247). I would like to clarify what I have done here. 

- I have recreated context service but this time decoupling as much as possible. 
- Context does a good job to support the `validate` command as it needs only one spec file path. But to support libraries like [cupid](https://github.com/asyncapi/cupid) and [diff](https://github.com/asyncapi/diff) where more than one spec file path is needed context shall evolve as well. For that, I have created a separate `IContext` interface that could be easily updated. 
- To support the future ambition of loading context files [from the root directory and to be sharable](https://github.com/asyncapi/cli/issues/38#issue-952937304) I have created a separate class `ContextAllocator` to load context files accordingly. For now, it is loading the context file from the root file itself. This also helps in testing allowing us to create mock classes to check functionalities. 
- Now `ContextService` does not throw an error if the contextFile is not present in the root dir instead it loads undefined context. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

See also #38 and #37