### PR TITLE
fix: add newline at the end of help

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	},
 	"scripts": {
 		"build": "tsc",
+		"dev": "tsc --watch",
 		"start": "npm run build && node dist/cli.js",
 		"pretest": "npm run build",
 		"pretest:coverage": "npm run build",

--- a/src/help-message.tsx
+++ b/src/help-message.tsx
@@ -97,6 +97,7 @@ export class HelpMessageBuilder {
       {Object.keys(this.helpMessage.commands).map(command => <Text key={command}>
         <Text color="blueBright" bold>{command}</Text>{' '} <Text>{this.helpMessage.commands[command as CommandName].shortDescription}</Text>
       </Text>)}
+      <Newline />
     </>;
   }
 


### PR DESCRIPTION
### Description

I'm adding a new line at the end of the `asyncapi --help` command to prevent last line from being mixed with the terminal stuff:

![Captura de pantalla 2021-09-24 a las 19 21 44](https://user-images.githubusercontent.com/242119/134715742-0a3cd24c-fe24-4d78-8e4f-1ba33bc3824f.png)

It now looks like this:
![Captura de pantalla 2021-09-24 a las 19 23 27](https://user-images.githubusercontent.com/242119/134715939-4f0b6124-60aa-4c4b-9bef-116e229916c8.png)

I'm also adding the `npm run dev` script to ease development.
