### PR TITLE
feat: adding default file extension for users

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -81,7 +81,7 @@ export default class New extends Command {
   async createAsyncapiFile(fileName:string) {
     const defaultAsyncapiFile = await readFile(resolve(__dirname, '../../assets/asyncapi.yaml'), { encoding: 'utf8' });
 
-    const fileNameHasFileExtension = fileName.includes('.')
+    const fileNameHasFileExtension = fileName.includes('.');
     const fileNameToWriteToDisk = fileNameHasFileExtension ? fileName : `${fileName}.yaml`;
 
     try {

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -81,7 +81,7 @@ export default class New extends Command {
   async createAsyncapiFile(fileName:string) {
     const defaultAsyncapiFile = await readFile(resolve(__dirname, '../../assets/asyncapi.yaml'), { encoding: 'utf8' });
 
-    const fileNameHasFileExtension = fileName.split('.').pop() !== fileName;
+    const fileNameHasFileExtension = fileName.includes('.')
     const fileNameToWriteToDisk = fileNameHasFileExtension ? fileName : `${fileName}.yaml`;
 
     try {

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -81,17 +81,20 @@ export default class New extends Command {
   async createAsyncapiFile(fileName:string) {
     const defaultAsyncapiFile = await readFile(resolve(__dirname, '../../assets/asyncapi.yaml'), { encoding: 'utf8' });
 
+    const fileNameHasFileExtension = fileName.split('.').pop() !== fileName;
+    const fileNameToWriteToDisk = fileNameHasFileExtension ? fileName : `${fileName}.yaml`;
+
     try {
-      const content = await readFile(fileName, { encoding: 'utf8' });
+      const content = await readFile(fileNameToWriteToDisk, { encoding: 'utf8' });
       if (content !== '') {
-        console.log(`File ${fileName} already exists. Ignoring...`);
+        console.log(`File ${fileNameToWriteToDisk} already exists. Ignoring...`);
         return;
       }
     } catch (e) {
       // File does not exist. Proceed creating it...
     }
     
-    await writeFile(fileName, defaultAsyncapiFile, { encoding: 'utf8' });
-    console.log(`Created file ${fileName}...`);
+    await writeFile(fileNameToWriteToDisk, defaultAsyncapiFile, { encoding: 'utf8' });
+    console.log(`Created file ${fileNameToWriteToDisk}...`);
   }
 }


### PR DESCRIPTION
**Description**

When user uses the `new` command they are asked for the `filename`. 

If the user does not provide a file extension the file is created.

This PR will check to see if any file extension has been made, and will add `.yaml` onto the filename if no extension has been provided.

### Why

Just think it's a slightly better developer experience than allowing them to have files without extensions as async API files.

Related issue #114 