### PR TITLE
fix: cli not working once published

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
   },
   "files": [
     "/bin",
+    "/lib",
     "/npm-shrinkwrap.json",
-    "/oclif.manifest.json",
-    "dist"
+    "/oclif.manifest.json"
   ],
   "homepage": "https://github.com/asyncapi/cli",
   "keywords": [


### PR DESCRIPTION
**Description**
The CLI is not working once published. For instance, if you try to install it globally with `npm i -g @asyncapi/cli` and then try to run a command, it will fail with an error similar to the one described below. Everything fails except `--help`, which is probably being rendered from the oclif.manifest.json file.

```
$ asyncapi config context add
    Error: Cannot find module '/Users/fmvilas/.nvm/versions/node/v14.15.1/lib/node_modules/@a
    syncapi/cli/lib/commands/config/context/add'
    Require stack:
    - /Users/fmvilas/.nvm/versions/node/v14.15.1/lib/node_modules/@asyncapi/cli/node_modules/
    @oclif/config/lib/plugin.js
    - /Users/fmvilas/.nvm/versions/node/v14.15.1/lib/node_modules/@asyncapi/cli/node_modules/
    @oclif/config/lib/config.js
    - /Users/fmvilas/.nvm/versions/node/v14.15.1/lib/node_modules/@asyncapi/cli/node_modules/
    @oclif/config/lib/index.js
    - /Users/fmvilas/.nvm/versions/node/v14.15.1/lib/node_modules/@asyncapi/cli/node_modules/
    @oclif/command/lib/command.js
    - /Users/fmvilas/.nvm/versions/node/v14.15.1/lib/node_modules/@asyncapi/cli/node_modules/
    @oclif/command/lib/index.js
    - /Users/fmvilas/.nvm/versions/node/v14.15.1/lib/node_modules/@asyncapi/cli/bin/run
    Code: MODULE_NOT_FOUND
```

A quick look at the `lib` folder inside the module shows that it's empty 😱 Only an `index.js` file is there and it's not doing much.

```
ll /Users/fmvilas/.nvm/versions/node/v14.15.1/lib/node_modules/\@asyncapi/cli/lib/

total 8
drwxr-xr-x  3 fmvilas  staff    96B  3 nov 07:27 .
drwxr-xr-x  9 fmvilas  staff   288B  3 nov 07:28 ..
-rw-r--r--  1 fmvilas  staff   225B 26 oct  1985 index.js
```

That makes me think that the `files` property in the `package.json` file is tricking us. I'm not sure if I'm fixing the error (we'll see after merging this PR) but what's for sure is that the `lib` folder should be there once the module is installed and that `dist` doesn't make sense anymore as that's part of the previous codebase.