### PR TITLE
fix: issue with prepack command  that blocks release

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "pretest": "npm run build",
     "pretest:coverage": "npm run build",
     "release": "semantic-release",
-    "test": "cross-env TEST=1 CONTEXT_FILENAME=\"./test.asyncapi\" CONTEXT_FILE_PATH=\"./\" nyc --extension .ts mocha --require ts-node/register --require test/helpers/init.js --reporter spec --timeout 10000 \"test/**/*.test.ts\"",
+    "test": "cross-env TEST=1 CONTEXT_FILENAME=\"./test.asyncapi\" CONTEXT_FILE_PATH=\"./\" nyc --extension .ts mocha --require ts-node/register --require test/helpers/init.js --reporter spec --timeout 10000 \"test/**/*.test.ts\""
   },
   "types": "lib/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "lint": "eslint --max-warnings 0 --config .eslintrc .",
     "lint:fix": "eslint --max-warnings 5 --config .eslintrc . --fix",
     "postpack": "rimraf oclif.manifest.json",
-    "prepack": "rimraf lib && tsc -b && oclif manifest && oclif readme",
+    "prepack": "npm run build && oclif manifest && oclif readme",
     "prepublishOnly": "npm run build",
     "pretest": "npm run build",
     "pretest:coverage": "npm run build",

--- a/package.json
+++ b/package.json
@@ -131,15 +131,11 @@
     "lint": "eslint --max-warnings 0 --config .eslintrc .",
     "lint:fix": "eslint --max-warnings 5 --config .eslintrc . --fix",
     "postpack": "rimraf oclif.manifest.json",
-    "prepack": "npm run build && oclif manifest && oclif readme",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && oclif manifest",
     "pretest": "npm run build",
     "pretest:coverage": "npm run build",
     "release": "semantic-release",
-    "start": "npm run build && node dist/cli.js",
-    "version": "oclif readme && git add README.md",
     "test": "cross-env TEST=1 CONTEXT_FILENAME=\"./test.asyncapi\" CONTEXT_FILE_PATH=\"./\" nyc --extension .ts mocha --require ts-node/register --require test/helpers/init.js --reporter spec --timeout 10000 \"test/**/*.test.ts\"",
-    "readme": "oclif readme"
   },
   "types": "lib/index.d.ts"
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Trying to fix the issue with `npm prepack` command holding of the gh action and not able to publish. 

Still now clear what is causing the issue, since not much log is present, as of now two action run has failed for this 

- https://github.com/asyncapi/cli/runs/5474535742?check_suite_focus=true 
- https://github.com/asyncapi/cli/runs/5391166652?check_suite_focus=true

I tried running the command separately on my fork and it ran not sure why it is having issues here - https://github.com/Souvikns/cli/runs/5469720664?check_suite_focus=true 


