### PR TITLE
feat: integrate asyncapi optimize library using the optimize command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
   },
   "bugs": "https://github.com/asyncapi/cli/issues",
   "dependencies": {
-    "@oclif/core": "^1.2.0",
     "@asyncapi/diff": "^0.3.0",
+    "@asyncapi/optimizer": "^0.1.6",
     "@asyncapi/parser": "^1.14.0",
-    "@oclif/plugin-not-found": "^2.3.1",
     "@asyncapi/studio": "^0.10.0",
+    "@oclif/core": "^1.2.0",
+    "@oclif/plugin-not-found": "^2.3.1",
     "@types/inquirer": "^8.1.3",
     "@types/ws": "^8.2.0",
     "chalk": "^4.1.0",
@@ -63,8 +64,8 @@
     "rimraf": "^3.0.2",
     "semantic-release": "^17.4.3",
     "ts-node": "^10.4.0",
-    "typescript": "^4.4.3",
-    "tslib": "^2.3.1"
+    "tslib": "^2.3.1",
+    "typescript": "^4.4.3"
   },
   "engines": {
     "node": ">12.16"

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -1,0 +1,19 @@
+import {Flags} from '@oclif/core';
+import Command from '../base';
+import * as optimizer from '@asyncapi/optimizer';
+
+import { load } from '../models/SpecificationFile';
+
+export default class Optimize extends Command {
+  static description = 'starts a new local instance of Studio';
+
+  static flags = {
+    help: Flags.help({ char: 'h' }),
+  }
+
+  static args = []
+
+  async run() {
+    const { args,flags } = await this.parse(Optimize);
+  }
+}

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -1,19 +1,31 @@
 import {Flags} from '@oclif/core';
 import Command from '../base';
-import * as optimizer from '@asyncapi/optimizer';
+import { Optimizer } from '@asyncapi/optimizer';
 
 import { load } from '../models/SpecificationFile';
 
 export default class Optimize extends Command {
-  static description = 'starts a new local instance of Studio';
+  static description = 'It enables users to optimize single AsyncAPI file';
 
   static flags = {
     help: Flags.help({ char: 'h' }),
+    report: Flags.boolean({ char: 'r', description: 'generates report' }),
   }
 
-  static args = []
+  static args = [
+    { name: 'file', description: 'context,filepath or url', required: true },
+  ]
 
   async run() {
     const { args,flags } = await this.parse(Optimize);
+    const filePath = args['file'];
+    const file = await load(filePath);
+    const optimizer = new Optimizer(file);
+    const report = optimizer.getOptimizedDocument();
+    this.log(report);
+    if (flags.report) {
+      const report = await optimizer.getReport();
+      this.log(String(report));
+    }
   }
 }


### PR DESCRIPTION

**Description**

This PR integrates the [asyncapi-optimize](https://github.com/asyncapi/optimizer) library using the optimize command.

At the moment, the command looks something like this.

`asyncapi optimize <context/filepath/url>`

And it has flag:
--format which determines the show the report or not.



**Related issue(s)**
Fixes #218 