### PR TITLE
feat: extend error handling in validate command

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,19 +8,19 @@ In the interest of fostering an open and welcoming environment, we as contributo
 
 Examples of behavior that contributes to creating a positive environment include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities
 
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-You may report instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at fmvilas@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality concerning the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at fmvilas@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -5,7 +5,6 @@ import { ValidationError } from '../errors/validation-error';
 import { load } from '../models/SpecificationFile';
 import { specWatcher } from '../globals';
 import { watchFlag } from '../flags';
-import { SpecificationFileNotFound } from '../errors/specification-file';
 
 export default class Validate extends Command {
   static description = 'validate asyncapi file';
@@ -22,19 +21,14 @@ export default class Validate extends Command {
   async run() {
     const { args, flags } = await this.parse(Validate); //NOSONAR
     const filePath = args['spec-file'];
-
     const watchMode = flags['watch'];
 
     const specFile = await load(filePath);
     if (watchMode) {
-      specWatcher({spec: specFile, handler: this, handlerName: 'validate'});
+      specWatcher({ spec: specFile, handler: this, handlerName: 'validate' });
     }
-    try {
-      const specFile = await load(filePath);
-      if (watchMode) {
-        specWatcher({ spec: specFile, handler: this, handlerName: 'validate' });
-      }
-
+    
+    try {  
       if (specFile.getFilePath()) {
         await parser.parse(specFile.text());
         this.log(`File ${specFile.getFilePath()} successfully validated!`);
@@ -42,15 +36,11 @@ export default class Validate extends Command {
         await parser.parse(specFile.text());
         this.log(`URL ${specFile.getFileURL()} successfully validated`);
       }
-    } catch (e) {
-      if (e instanceof SpecificationFileNotFound) {
-        this.error(e);
-      } else {
-        throw new ValidationError({
-          type: 'parser-error',
-          err: e
-        });
-      }
+    } catch (error) {
+      throw new ValidationError({
+        type: 'parser-error',
+        err: error
+      });
     }
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,10 +1,11 @@
-import {Flags} from '@oclif/core';
+import { Flags } from '@oclif/core';
 import * as parser from '@asyncapi/parser';
 import Command from '../base';
 import { ValidationError } from '../errors/validation-error';
 import { load } from '../models/SpecificationFile';
 import { specWatcher } from '../globals';
 import { watchFlag } from '../flags';
+import { SpecificationFileNotFound } from '../errors/specification-file';
 
 export default class Validate extends Command {
   static description = 'validate asyncapi file';
@@ -21,14 +22,15 @@ export default class Validate extends Command {
   async run() {
     const { args, flags } = await this.parse(Validate); //NOSONAR
     const filePath = args['spec-file'];
-
     const watchMode = flags['watch'];
 
-    const specFile = await load(filePath);
-    if (watchMode) {
-      specWatcher({spec: specFile, handler: this, handlerName: 'validate'});
-    }
     try {
+      const specFile = await load(filePath);
+
+      if (watchMode) {
+        specWatcher({ spec: specFile, handler: this, handlerName: 'validate' });
+      }
+
       if (specFile.getFilePath()) {
         await parser.parse(specFile.text());
         this.log(`File ${specFile.getFilePath()} successfully validated!`);
@@ -36,11 +38,18 @@ export default class Validate extends Command {
         await parser.parse(specFile.text());
         this.log(`URL ${specFile.getFileURL()} successfully validated`);
       }
-    } catch (error) {
-      throw new ValidationError({
-        type: 'parser-error',
-        err: error
-      });
+    } catch (e) {
+      if (e instanceof SpecificationFileNotFound) {
+        this.error(new ValidationError({
+          type: 'invalid-file',
+          filepath: filePath
+        }));
+      } else {
+        throw new ValidationError({
+          type: 'parser-error',
+          err: e
+        });
+      }
     }
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -44,10 +44,7 @@ export default class Validate extends Command {
       }
     } catch (e) {
       if (e instanceof SpecificationFileNotFound) {
-        this.error(new ValidationError({
-          type: 'invalid-file',
-          filepath: filePath
-        }));
+        this.error(e);
       } else {
         throw new ValidationError({
           type: 'parser-error',

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -5,7 +5,7 @@ import { ValidationError } from '../errors/validation-error';
 import { load } from '../models/SpecificationFile';
 import { specWatcher } from '../globals';
 import { watchFlag } from '../flags';
-import { SpecificationFileNotFound } from '../errors/specification-file';
+//import { SpecificationFileNotFound } from '../errors/specification-file';
 
 export default class Validate extends Command {
   static description = 'validate asyncapi file';
@@ -23,14 +23,12 @@ export default class Validate extends Command {
     const { args, flags } = await this.parse(Validate); //NOSONAR
     const filePath = args['spec-file'];
     const watchMode = flags['watch'];
-
+    
+    const specFile = await load(filePath);
+    if (watchMode) {
+      specWatcher({ spec: specFile, handler: this, handlerName: 'validate' });
+    }
     try {
-      const specFile = await load(filePath);
-
-      if (watchMode) {
-        specWatcher({ spec: specFile, handler: this, handlerName: 'validate' });
-      }
-
       if (specFile.getFilePath()) {
         await parser.parse(specFile.text());
         this.log(`File ${specFile.getFilePath()} successfully validated!`);
@@ -38,18 +36,11 @@ export default class Validate extends Command {
         await parser.parse(specFile.text());
         this.log(`URL ${specFile.getFileURL()} successfully validated`);
       }
-    } catch (e) {
-      if (e instanceof SpecificationFileNotFound) {
-        this.error(new ValidationError({
-          type: 'invalid-file',
-          filepath: filePath
-        }));
-      } else {
-        throw new ValidationError({
-          type: 'parser-error',
-          err: e
-        });
-      }
+    } catch (error) {
+      throw new ValidationError({
+        type: 'parser-error',
+        err: error
+      });
     }
   }
 }

--- a/src/errors/specification-file.ts
+++ b/src/errors/specification-file.ts
@@ -34,15 +34,15 @@ export class ErrorLoadingSpec extends Error {
     super();
     if (from === 'file') {
       this.name = 'error loading AsyncAPI document from file';
-      this.message = `${param} is an invalid file path`;
+      this.message = `${param} file does not exist.`;
     }
     if (from === 'url') {
       this.name = 'error loading AsyncAPI document from url';
-      this.message = `${param} is an invalid url`;
+      this.message = `${param} url does not exist.`;
     }
     if (from === 'context') {
       this.name = 'error loading AsyncAPI document from context';
-      this.message = `${param} is an invalid context name`;
+      this.message = `${param} context name does not exist.`;
     }
 
     if (!from) {

--- a/src/errors/specification-file.ts
+++ b/src/errors/specification-file.ts
@@ -37,7 +37,7 @@ export class ErrorLoadingSpec extends Error {
       this.message = `${param} is an invalid file path`;
     }
     if (from === 'url') {
-      this.name = 'error loading AsyncAPI docuement from url';
+      this.name = 'error loading AsyncAPI document from url';
       this.message = `${param} is an invalid url`;
     }
     if (from === 'context') {

--- a/src/errors/specification-file.ts
+++ b/src/errors/specification-file.ts
@@ -38,7 +38,7 @@ export class ErrorLoadingSpec extends Error {
     }
     if (from === 'url') {
       this.name = 'error loading AsyncAPI document from url';
-      this.message = `${param} url does not exist.`;
+      this.message = `Failed to download ${param}.`;
     }
     if (from === 'context') {
       this.name = 'error loading AsyncAPI document from context';

--- a/test/commands/convert.test.ts
+++ b/test/commands/convert.test.ts
@@ -28,7 +28,7 @@ describe('convert', () => {
       .command(['convert', './test/not-found.yml'])
       .it('should throw error if file path is wrong', (ctx, done) => {
         expect(ctx.stdout).to.equals('');
-        expect(ctx.stderr).to.equals('error loading AsyncAPI document from file: ./test/not-found.yml is an invalid file path\n');
+        expect(ctx.stderr).to.equals('error loading AsyncAPI document from file: ./test/not-found.yml file does not exist.\n');
         done();
       });
 

--- a/test/commands/validate.test.ts
+++ b/test/commands/validate.test.ts
@@ -31,7 +31,7 @@ describe('validate', () => {
       .command(['validate', './test/not-found.yml'])
       .it('should throw error if file path is wrong', (ctx, done) => {
         expect(ctx.stdout).to.equals('');
-        expect(ctx.stderr).to.equals('error loading AsyncAPI document from file: ./test/not-found.yml is an invalid file path\n');
+        expect(ctx.stderr).to.equals('error loading AsyncAPI document from file: ./test/not-found.yml file does not exist.\n');
         done();
       });
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Error handling added when loading a spec file for `validate` command, since this process was not handled before in case of error.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
- See also #288 