### PR TITLE
fix: remove script that should not run on a release on ubuntu

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "pack:windows": "oclif pack:win",
     "pack:macos:rename": "node scripts/macosPackRename.js",
     "postpack": "rimraf oclif.manifest.json",
-    "postpublish": "npm run pack:macos",
     "prepublishOnly": "npm run build && oclif manifest",
     "pretest": "npm run build",
     "pretest:coverage": "npm run build",


### PR DESCRIPTION
we need to remove this script. I do not remember why I added it in the first place. This should not run after publishing the package for 2 reasons:
- package is already published, what is the point
- release runs on ubuntu so macOS building will always fail