### PR TITLE
fix: make sure release assets are uploaded to latest release

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -1,13 +1,16 @@
 name: Upload custom assets to GitHub release
 
-on: 
-  release:
-    types: 
-      - published
+on:
+  # It cannot run on release event as when release is created then version is not yet bumped in package.json
+  # This means we cannot extract easily latest version and have a risk that package is not yet on npm
+  push:
+    branches:
+      - master
 
 jobs:
   upload-assets:
     name: Generate and upload assets
+    if: startsWith(github.event.commits[0].message, 'chore(release):')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -38,6 +41,9 @@ jobs:
           node-version: 14
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
+      - name: Get version from package.json
+        id: extractver
+        run: echo "::set-output name=version::$(npm run get-version --silent)"
       - name: Install dependencies
         run: npm install
       - name: Assets generation
@@ -46,4 +52,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: dist/${{ matrix.dist_folder }}/asyncapi.${{ matrix.extension }}
-          tag_name: ${{github.event.release.tag_name}}
+          tag_name: ${{ steps.extractver.outputs.version }}

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -30,11 +30,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          # target branch of release. More info https://docs.github.com/en/rest/reference/repos#releases
-          # in case release is created from release branch then we need to checkout from given branch
-          # if @semantic-release/github is used to publish, the minimum version is 7.2.0 for proper working
-          ref: ${{ github.event.release.target_commitish }}
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
@@ -52,4 +47,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: dist/${{ matrix.dist_folder }}/asyncapi.${{ matrix.extension }}
-          tag_name: ${{ steps.extractver.outputs.version }}
+          tag_name: v${{ steps.extractver.outputs.version }}
+          token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -38,9 +38,6 @@ jobs:
           node-version: 14
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
-      - name: Get version from package.json
-        id: extractver
-        run: echo "::set-output name=version::$(npm run get-version --silent)"
       - name: Install dependencies
         run: npm install
       - name: Assets generation
@@ -49,4 +46,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: dist/${{ matrix.dist_folder }}/asyncapi.${{ matrix.extension }}
-          tag_name: ${{ steps.extractver.outputs.version }}
+          tag_name: ${{github.event.release.tag_name}}


### PR DESCRIPTION
So:
- brew automation works https://github.com/Homebrew/homebrew-core/pull/104709
- assets upload (pkg for example) works too https://github.com/asyncapi/cli/releases/tag/0.19.5 but as you can see, it created wrong release instead of using latest. Also wrong bot is used

This PR fixes upload to work on push, and not release because when we have release event, package.json is not yet updated in the repo