### PR TITLE
fix: build project before publishing pkg

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -41,6 +41,8 @@ jobs:
         run: echo "::set-output name=version::$(npm run get-version --silent)"
       - name: Install dependencies
         run: npm install
+      - name: Build project
+        run: npm run prepublishOnly
       - name: Assets generation
         run: npm run ${{ matrix.npm_script }}
       - name: Update release


### PR DESCRIPTION
I do not like projects that assume you know how things work 😞 I'm tired of digging into code of every single project that I want to use 😞 

so, `pkg` artifact is broken, it publishes empty CLI:
```
$ asyncapi
All in one CLI for all AsyncAPI tools

VERSION
  @asyncapi/cli/0.21.0 darwin-x64 node-v16.4.0

USAGE
  $ asyncapi [COMMAND]

TOPICS
  config
```

It is because the workflow doesn't build the project. I did it intentionally as in docs they described some stuff about npm, tarball and in logs I could see npm tarball is inspected. I was 100% sure it takes tarball from NPM during artifact creation...and I was so wrong, sorry

This PR adds a build step that will fix the issue:
```
#####
removed lib manually
#####
$ bin/run
All in one CLI for all AsyncAPI tools

VERSION
  @asyncapi/cli/0.21.0 darwin-x64 node-v16.4.0

USAGE
  $ asyncapi [COMMAND]

TOPICS
  config

#####
running build
#####
$ npm run prepublishOnly

> @asyncapi/cli@0.21.0 prepublishOnly
> npm run build && oclif manifest


> @asyncapi/cli@0.21.0 build
> rimraf lib && node scripts/fetch-asyncapi-example.js && tsc && echo "Build Completed"

Fetched ZIP file
Unzipped all examples from zip
Build Completed
started command oclif manifest
[ARGS]:  {"path":"."}
[ROOT]:  /Users/wookiee/sources/cli
[PLUGIN]:  {"options":{"root":"/Users/wookiee/sources/cli","type":"core","ignoreManifest":true,"errorOnManifestCreate":true},"_base":"@oclif/core@1.8.1","valid":false,"alreadyLoaded":false,"children":[],"warned":false}
Loading plugin
plugin loaded
[DOTFILE]:  undefined
[FILE]:  /Users/wookiee/sources/cli/oclif.manifest.json
wrote manifest to /Users/wookiee/sources/cli/oclif.manifest.json
end command oclif manifest

#####
when lib is there
#####
$ bin/run
All in one CLI for all AsyncAPI tools

VERSION
  @asyncapi/cli/0.21.0 darwin-x64 node-v16.4.0

USAGE
  $ asyncapi [COMMAND]

TOPICS
  config
  generate  Generates typed models
  start

COMMANDS
  config
  convert   convert asyncapi documents older to newer versions
  diff      find diff between two asyncapi files
  new       creates a new asyncapi file
  start
  validate  validate asyncapi file
```