### PR TITLE
feat: add optional parameters to typescript model generator

### DIFF
--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -35,25 +35,25 @@ export default class Models extends Command {
     /**
      * TypeScript specific options
      */
-    modelType: Flags.string({
+    tsModelType: Flags.string({
       type: 'option',
       options: ['class', 'interface'],
       description: 'TypeScript specific, define which type of model needs to be generated.',
       required: false,
     }),
-    enumType: Flags.string({
+    tsEnumType: Flags.string({
       type: 'option',
       options: ['enum', 'union'],
       description: 'TypeScript specific, define which type of enums needs to be generated.',
       required: false,
     }),
-    moduleSystem: Flags.string({
+    tsModuleSystem: Flags.string({
       type: 'option',
       options: ['ESM', 'CJS'],
       description: 'TypeScript specific, define the module system to be used.',
       required: false,
     }),
-    exportType: Flags.string({
+    tsExportType: Flags.string({
       type: 'option',
       options: ['default', 'named'],
       description: 'TypeScript specific, define which type of export needs to be generated.',
@@ -77,7 +77,7 @@ export default class Models extends Command {
 
   async run() {
     const passedArguments = await this.parse(Models);
-    const { modelType, enumType, moduleSystem, exportType, namespace, packageName, output } = passedArguments.flags;
+    const { tsModelType, tsEnumType, tsModuleSystem, tsExportType, namespace, packageName, output } = passedArguments.flags;
     const { language, file } = passedArguments.args;
     const inputFile = await load(file) || await load();
     const parsedInput = await parse(inputFile.text());
@@ -100,12 +100,12 @@ export default class Models extends Command {
     switch (language) {
     case Languages.typescript:
       fileGenerator = new TypeScriptFileGenerator({
-        modelType: modelType as undefined | 'class' | 'interface',
-        enumType: enumType as undefined | 'enum' | 'union'
+        modelType: tsModelType as undefined | 'class' | 'interface',
+        enumType: tsEnumType as undefined | 'enum' | 'union'
       });
       fileOptions = {
-        moduleSystem,
-        exportType
+        moduleSystem: tsModuleSystem,
+        exportType: tsExportType
       };
       break;
     case Languages.csharp:


### PR DESCRIPTION
**Description**

Implements optional parameters for typescript model generator.

<img width="1777" alt="Screen Shot 2022-11-07 at 9 24 44 PM" src="https://user-images.githubusercontent.com/1027219/200459680-3c211790-8e0a-40ab-9a89-63a1ebbb6206.png">

Test results:

<img width="1544" alt="Screen Shot 2022-11-07 at 9 22 13 PM" src="https://user-images.githubusercontent.com/1027219/200459454-8f1d73e5-230a-480c-95f6-f7cc568d6f67.png">

Tested various other combinations. Implementation was pretty simple.

**Related issue(s)**
Fixes #383 