### PR TITLE
feat: add new example to `asyncapi new` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /yarn.lock
 /assets/examples/**
 !assets/examples/default-example.yaml
+!assets/examples/tutorial.yml
 node_modules
 /test/commands/generate/models/
 asyncapi.json

--- a/assets/examples/tutorial.yml
+++ b/assets/examples/tutorial.yml
@@ -1,0 +1,37 @@
+asyncapi: 2.5.0
+info:
+  title: Streetlights API Simplified
+  version: 1.0.0
+  description: |
+    The Smartylighting Streetlights API allows you to remotely manage the city lights.
+
+    This is a simplified version of the Streetlights API from other examples. This version is used in AsyncAPI documentation.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+servers:
+  mosquitto:
+    url: mqtt://test.mosquitto.org
+    protocol: mqtt
+channels:
+  light/measured:
+    publish:
+      summary: Inform about environmental lighting conditions for a particular streetlight.
+      operationId: onLightMeasured
+      message:
+        name: LightMeasured
+        payload:
+          type: object
+          properties:
+            id:
+              type: integer
+              minimum: 0
+              description: Id of the streetlight.
+            lumens:
+              type: integer
+              minimum: 0
+              description: Light intensity measured in lumens.
+            sentAt:
+              type: string
+              format: date-time
+              description: Date and time when the message was sent.

--- a/scripts/fetch-asyncapi-example.js
+++ b/scripts/fetch-asyncapi-example.js
@@ -6,7 +6,7 @@ const unzipper = require('unzipper');
 const path = require('path');
 const parser = require('@asyncapi/parser');
 
-const SPEC_EXAMPLES_ZIP_URL = 'https://github.com/asyncapi/spec/archive/refs/tags/v2.3.0.zip';
+const SPEC_EXAMPLES_ZIP_URL = 'https://github.com/asyncapi/spec/archive/refs/heads/master.zip';
 const EXAMPLE_DIRECTORY = path.join(__dirname, '../assets/examples');
 const TEMP_ZIP_NAME = 'spec-examples.zip';
 


### PR DESCRIPTION
The idea of a new example is to have it reflect the same example that is used in docs.

why? so tutorials can have a simple command that reader can use to bootstrap example asyncapi file if they do not have any:
```
asyncapi new --example=tutorial.yml --no-tty
```

Resolve https://github.com/asyncapi/cli/issues/205