### PR TITLE
feat: extend validation error with link to validated document

### DIFF
--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,5 +1,6 @@
 import { Flags } from '@oclif/core';
 import * as parser from '@asyncapi/parser';
+import path from 'path';
 import Command from '../base';
 import { ValidationError } from '../errors/validation-error';
 import { load } from '../models/SpecificationFile';
@@ -37,9 +38,12 @@ export default class Validate extends Command {
         this.log(`URL ${specFile.getFileURL()} successfully validated`);
       }
     } catch (error) {
+      const filepath : any = specFile.getFilePath();
+      
       throw new ValidationError({
         type: 'parser-error',
-        err: error
+        err: error,
+        filepath: specFile.getFileURL() || path.resolve(process.cwd(), filepath)
       });
     }
   }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -38,7 +38,7 @@ export default class Validate extends Command {
         this.log(`URL ${specFile.getFileURL()} successfully validated`);
       }
     } catch (error) {
-      const filepath : any = specFile.getFilePath();
+      const filepath= specFile.getFilePath() as string;
       
       throw new ValidationError({
         type: 'parser-error',

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -38,12 +38,12 @@ export default class Validate extends Command {
         this.log(`URL ${specFile.getFileURL()} successfully validated`);
       }
     } catch (error) {
-      const filepath= specFile.getFilePath() as string;
+      const filePath= specFile.getFilePath() as string;
       
       throw new ValidationError({
         type: 'parser-error',
         err: error,
-        filepath: specFile.getFileURL() || path.resolve(process.cwd(), filepath)
+        filepath: specFile.getFileURL() || path.resolve(process.cwd(), filePath)
       });
     }
   }

--- a/src/errors/validation-error.ts
+++ b/src/errors/validation-error.ts
@@ -22,7 +22,7 @@ export class ValidationError extends Error {
   }
 
   /* eslint-disable sonarjs/cognitive-complexity */
-  private buildError(err: any, filePath: any) { // NOSONAR
+  private buildError(err: any, filePath: string) { // NOSONAR
     const errorsInfo: Array<string> = [];
 
     if (filePath) {

--- a/src/errors/validation-error.ts
+++ b/src/errors/validation-error.ts
@@ -3,14 +3,14 @@ type ErrorType = 'parser-error' | 'invalid-file' | 'no-spec-found';
 interface IValidationErrorInput {
   type: ErrorType;
   err?: any,
-  filepath?: string,
+  filepath?: any,
 }
 
 export class ValidationError extends Error {
   constructor(error: IValidationErrorInput) {
     super();
     if (error.type === 'parser-error') {
-      this.buildError(error.err);
+      this.buildError(error.err, error.filepath);
     }
     if (error.type === 'invalid-file') {
       this.message = `There is no file or context with name "${error.filepath}".`;
@@ -21,8 +21,13 @@ export class ValidationError extends Error {
     this.name = 'ValidationError';
   }
 
-  private buildError(err: any) {
+  /* eslint-disable sonarjs/cognitive-complexity */
+  private buildError(err: any, filepath: any) {
     const errorsInfo: Array<string> = [];
+
+    if (filepath) {
+      errorsInfo.push(`We tried to validate ${filepath}.`);
+    }
 
     if (err.title) {
       errorsInfo.push(err.title);

--- a/src/errors/validation-error.ts
+++ b/src/errors/validation-error.ts
@@ -22,7 +22,7 @@ export class ValidationError extends Error {
   }
 
   /* eslint-disable sonarjs/cognitive-complexity */
-  private buildError(err: any, filePath: string) { // NOSONAR
+  private buildError(err: any, filePath: any) { // NOSONAR
     const errorsInfo: Array<string> = [];
 
     if (filePath) {

--- a/src/errors/validation-error.ts
+++ b/src/errors/validation-error.ts
@@ -3,7 +3,7 @@ type ErrorType = 'parser-error' | 'invalid-file' | 'no-spec-found';
 interface IValidationErrorInput {
   type: ErrorType;
   err?: any,
-  filepath?: any,
+  filepath?: string,
 }
 
 export class ValidationError extends Error {
@@ -22,11 +22,11 @@ export class ValidationError extends Error {
   }
 
   /* eslint-disable sonarjs/cognitive-complexity */
-  private buildError(err: any, filepath: any) { // NOSONAR
+  private buildError(err: any, filePath: any) { // NOSONAR
     const errorsInfo: Array<string> = [];
 
-    if (filepath) {
-      errorsInfo.push(`We tried to validate ${filepath}.`);
+    if (filePath) {
+      errorsInfo.push(`We tried to validate ${filePath}.`);
     }
 
     if (err.title) {

--- a/src/errors/validation-error.ts
+++ b/src/errors/validation-error.ts
@@ -22,7 +22,7 @@ export class ValidationError extends Error {
   }
 
   /* eslint-disable sonarjs/cognitive-complexity */
-  private buildError(err: any, filepath: any) {
+  private buildError(err: any, filepath: any) { // NOSONAR
     const errorsInfo: Array<string> = [];
 
     if (filepath) {


### PR DESCRIPTION
While reviewing `asyncapi optimize` PR I was getting errors when doing `asyncapi optimize` and `asyncapi validate` even though I had no context set and I was super angry and confused wtf.

I forgot we also load from working dir....yeah 😅 

This PR improves it. As result new error is:
```
$ asyncapi validate
ValidationError: Validation attempt of /Users/tratata/sources/cli/asyncapi.yaml.
There were errors validating the AsyncAPI document.
/info should NOT have additional properties 3:3
 

$ asyncapi validate https://raw.githubusercontent.com/starlightknown/studio/9b0dd15cc499ec7b5c64fbfc120a27bfc857d21d/src/examples/tutorials/invalid.yml
ValidationError: Validation attempt of https://raw.githubusercontent.com/starlightknown/studio/9b0dd15cc499ec7b5c64fbfc120a27bfc857d21d/src/examples/tutorials/invalid.yml.
Version 1.0.0 is not supported.
```

`Validation attempt of` is the new stuff added