### PR TITLE
feat: add parser plugins (#142)

### DIFF
--- a/scripts/fetch-asyncapi-example.js
+++ b/scripts/fetch-asyncapi-example.js
@@ -5,6 +5,13 @@ const fs = require('fs');
 const unzipper = require('unzipper');
 const path = require('path');
 const parser = require('@asyncapi/parser');
+const openapiSchemaParser = require('@asyncapi/openapi-schema-parser');
+const avroSchemaParser = require('@asyncapi/avro-schema-parser');
+const ramlDtSchemaParser = require('@asyncapi/raml-dt-schema-parser');
+
+parser.registerSchemaParser(openapiSchemaParser);
+parser.registerSchemaParser(avroSchemaParser);
+parser.registerSchemaParser(ramlDtSchemaParser);
 
 const SPEC_EXAMPLES_ZIP_URL = 'https://github.com/asyncapi/spec/archive/refs/heads/master.zip';
 const EXAMPLE_DIRECTORY = path.join(__dirname, '../assets/examples');

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -2,8 +2,8 @@
 import { Flags } from '@oclif/core';
 import * as diff from '@asyncapi/diff';
 import AsyncAPIDiff from '@asyncapi/diff/lib/asyncapidiff';
-import * as parser from '@asyncapi/parser';
 import { promises as fs } from 'fs';
+import * as parser from '../utils/parser';
 import { load, Specification } from '../models/SpecificationFile';
 import Command from '../base';
 import { ValidationError } from '../errors/validation-error';

--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -2,7 +2,7 @@ import { CSharpFileGenerator, JavaFileGenerator, JavaScriptFileGenerator, TypeSc
 import { Flags } from '@oclif/core';
 import Command from '../../base';
 import { load } from '../../models/SpecificationFile';
-import { parse } from '@asyncapi/parser';
+import { parse } from '../../utils/parser';
 enum Languages {
   typescript = 'typescript',
   csharp = 'csharp',

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core';
-import * as parser from '@asyncapi/parser';
+import * as parser from '../utils/parser';
 import Command from '../base';
 import { ValidationError } from '../errors/validation-error';
 import { load } from '../models/SpecificationFile';

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,5 @@
 declare module '@asyncapi/specs';
+
+declare module '@asyncapi/openapi-schema-parser';
+declare module '@asyncapi/avro-schema-parser';
+declare module '@asyncapi/raml-dt-schema-parser';

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,0 +1,10 @@
+import { parse, registerSchemaParser } from '@asyncapi/parser';
+import openapiSchemaParser from '@asyncapi/openapi-schema-parser';
+import avroSchemaParser from '@asyncapi/avro-schema-parser';
+import ramlDtSchemaParser from '@asyncapi/raml-dt-schema-parser';
+
+registerSchemaParser(openapiSchemaParser);
+registerSchemaParser(avroSchemaParser);
+registerSchemaParser(ramlDtSchemaParser);
+
+export { parse };

--- a/test/commands/validate.test.ts
+++ b/test/commands/validate.test.ts
@@ -33,6 +33,18 @@ describe('validate', () => {
     test
       .stderr()
       .stdout()
+      .command(['validate', './test/specification-avro.yml'])
+      .it('works when file path is passed and schema is avro', (ctx, done) => {
+        expect(ctx.stdout).toEqual(
+          'File ./test/specification-avro.yml successfully validated!\n'
+        );
+        expect(ctx.stderr).toEqual('');
+        done();
+      });
+
+    test
+      .stderr()
+      .stdout()
       .command(['validate', './test/not-found.yml'])
       .it('should throw error if file path is wrong', (ctx, done) => {
         expect(ctx.stdout).toEqual('');

--- a/test/specification-avro.yml
+++ b/test/specification-avro.yml
@@ -1,0 +1,25 @@
+asyncapi: 2.2.0
+info:
+  title: Account Service
+  version: 1.0.0
+  description: This service is in charge of processing user signups
+channels:
+  user/signedup:
+    subscribe:
+      message:
+        $ref: '#/components/messages/UserSignedUp'
+components:
+  messages:
+    UserSignedUp:
+      schemaFormat: 'application/vnd.apache.avro;version=1.9.0'
+      payload:
+        type: record
+        namespace: com.example
+        name: User
+        fields:
+          - name: displayName
+            type: string
+            doc: Name of the user
+          - name: email
+            type: string
+            doc: Email of the user


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Adds support for RAML, Avro and OpenAPI schemas.
- Adds test for `validate` command with an Avro schema.
- Note: `fetch-asyncapi-example.js` can not reuse `utils/parser.ts`, because it's a JS file, which can't import TS files.
- Thanks to @magicmatatjahu who basically gave [the complete solution](https://github.com/asyncapi/cli/issues/142#issuecomment-1197910374).


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

Resolves #142