### PR TITLE
feat: add Modelina configuration file support

### DIFF
--- a/test/commands/generate/__snapshots__/models.test.ts.snap
+++ b/test/commands/generate/__snapshots__/models.test.ts.snap
@@ -1,10 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`models for C# should handle configuration file 1`] = `
+"Successfully generated the following models: CustomUserSignedUpPayload
+"
+`;
+
+exports[`models for Dart should handle configuration file 1`] = `
+"Successfully generated the following models: CustomUserSignedUpPayload
+"
+`;
+
+exports[`models for Go should handle configuration file 1`] = `
+"Successfully generated the following models: CustomUserSignedUpPayload
+"
+`;
+
+exports[`models for Java should handle configuration file 1`] = `
+"Successfully generated the following models: CustomUserSignedUpPayload
+"
+`;
+
+exports[`models for JavaScript should handle configuration file 1`] = `
+"Successfully generated the following models: CustomUserSignedUpPayload
+"
+`;
+
+exports[`models for Python should handle configuration file 1`] = `
+"Successfully generated the following models: CustomUserSignedUpPayload
+"
+`;
+
+exports[`models for Rust should handle configuration file 1`] = `
+"Successfully generated the following models: CustomUserSignedUpPayload
+"
+`;
+
+exports[`models for TypeScript should handle configuration file 1`] = `
+"Successfully generated the following models: CustomUserSignedUpPayload
+"
+`;
+
+exports[`models should handle incorrect configuration file correctly 1`] = `
+"Error: There was an error trying to load the Modelina configuration file, it will be ignored. The following error was triggered: Error: 
+  × Expected ';', '}' or <eof>
+    ╭─[/Users/lagoni/Documents/github/cli/test/commands/generate/models_configuration/incorrect_models.js:12:1]
+ 12 │ WRONG SYNTAX
+    ·       ──────
+    ╰────
+
+Error: 
+  ☞ This is the expression part of an expression statement
+    ╭─[/Users/lagoni/Documents/github/cli/test/commands/generate/models_configuration/incorrect_models.js:12:1]
+ 12 │ WRONG SYNTAX
+    · ─────
+    ╰────
+
+
+Caused by:
+    0: failed to process input file
+    1: Syntax Error
+"
+`;
+
 exports[`models works when generating in memory 1`] = `
 "Successfully generated the following models: 
-## Model name: AnonymousSchema_1
+## Model name: UserSignedUpPayload
 
-class AnonymousSchema_1 {
+class UserSignedUpPayload {
   private _displayName?: string;
   private _email?: string;
   private _additionalProperties?: Map<string, any>;
@@ -28,7 +90,7 @@ class AnonymousSchema_1 {
   get additionalProperties(): Map<string, any> | undefined { return this._additionalProperties; }
   set additionalProperties(additionalProperties: Map<string, any> | undefined) { this._additionalProperties = additionalProperties; }
 }
-export default AnonymousSchema_1;
+export default UserSignedUpPayload;
 
 
 "

--- a/test/commands/generate/models.test.ts
+++ b/test/commands/generate/models.test.ts
@@ -15,13 +15,23 @@ describe('models', () => {
       expect(ctx.stdout).toMatchSnapshot();
       done();
     });
-    
+
   test
     .stderr()
     .stdout()
-    .command([...generalOptions, 'random', './test/specification.yml', `-o=${ path.resolve(outputDir, './random')}`])
+    .command([...generalOptions, 'random', './test/specification.yml', `-o=${path.resolve(outputDir, './random')}`])
     .it('fails when it dont know the language', (ctx, done) => {
       expect(ctx.stderr).toEqual('Error: Expected random to be one of: typescript, csharp, golang, java, javascript, dart, python, rust\nSee more help with --help\n');
+      expect(ctx.stdout).toEqual('');
+      done();
+    });
+
+  test
+    .stderr()
+    .stdout()
+    .command([...generalOptions, 'typescript', './test/specification.yml', `-o=${path.resolve(outputDir, './ts_config')}`, `-c=${path.resolve(__dirname, './models_configuration/incorrect_models.js')}`])
+    .it('should handle incorrect configuration file correctly', (ctx, done) => {
+      expect(ctx.stderr).toMatchSnapshot();
       expect(ctx.stdout).toEqual('');
       done();
     });
@@ -35,12 +45,12 @@ describe('models', () => {
       expect(ctx.stdout).toMatchSnapshot();
       done();
     });
-    
-  describe('for TypeScript', () => {  
+
+  describe('for TypeScript', () => {
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'typescript', './test/specification.yml', `-o=${ path.resolve(outputDir, './ts')}`])
+      .command([...generalOptions, 'typescript', './test/specification.yml', `-o=${path.resolve(outputDir, './ts')}`])
       .it('works when file path is passed', (ctx, done) => {
         expect(ctx.stderr).toEqual('');
         expect(ctx.stdout).toContain(
@@ -48,13 +58,23 @@ describe('models', () => {
         );
         done();
       });
-  });
 
-  describe('for JavaScript', () => {  
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'javascript', './test/specification.yml', `-o=${ path.resolve(outputDir, './js')}`])
+      .command([...generalOptions, 'typescript', './test/specification.yml', `-o=${path.resolve(outputDir, './ts_config')}`, `-c=${path.resolve(__dirname, './models_configuration/typescript_models.js')}`])
+      .it('should handle configuration file', (ctx, done) => {
+        expect(ctx.stderr).toEqual('');
+        expect(ctx.stdout).toMatchSnapshot();
+        done();
+      });
+  });
+
+  describe('for JavaScript', () => {
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'javascript', './test/specification.yml', `-o=${path.resolve(outputDir, './js')}`])
       .it('works when file path is passed', (ctx, done) => {
         expect(ctx.stdout).toContain(
           'Successfully generated the following models: '
@@ -62,13 +82,23 @@ describe('models', () => {
         expect(ctx.stderr).toEqual('');
         done();
       });
-  });
 
-  describe('for Python', () => {  
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'python', './test/specification.yml', `-o=${ path.resolve(outputDir, './python')}`])
+      .command([...generalOptions, 'javascript', './test/specification.yml', `-o=${path.resolve(outputDir, './ts_config')}`, `-c=${path.resolve(__dirname, './models_configuration/javascript_models.js')}`])
+      .it('should handle configuration file', (ctx, done) => {
+        expect(ctx.stderr).toEqual('');
+        expect(ctx.stdout).toMatchSnapshot();
+        done();
+      });
+  });
+
+  describe('for Python', () => {
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'python', './test/specification.yml', `-o=${path.resolve(outputDir, './python')}`])
       .it('works when file path is passed', (ctx, done) => {
         expect(ctx.stdout).toContain(
           'Successfully generated the following models: '
@@ -76,13 +106,23 @@ describe('models', () => {
         expect(ctx.stderr).toEqual('');
         done();
       });
-  });
 
-  describe('for Rust', () => {  
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'rust', './test/specification.yml', `-o=${ path.resolve(outputDir, './rust')}`])
+      .command([...generalOptions, 'python', './test/specification.yml', `-o=${path.resolve(outputDir, './ts_config')}`, `-c=${path.resolve(__dirname, './models_configuration/python_models.js')}`])
+      .it('should handle configuration file', (ctx, done) => {
+        expect(ctx.stderr).toEqual('');
+        expect(ctx.stdout).toMatchSnapshot();
+        done();
+      });
+  });
+
+  describe('for Rust', () => {
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'rust', './test/specification.yml', `-o=${path.resolve(outputDir, './rust')}`])
       .it('works when file path is passed', (ctx, done) => {
         expect(ctx.stdout).toContain(
           'Successfully generated the following models: '
@@ -90,9 +130,19 @@ describe('models', () => {
         expect(ctx.stderr).toEqual('');
         done();
       });
+
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'rust', './test/specification.yml', `-o=${path.resolve(outputDir, './ts_config')}`, `-c=${path.resolve(__dirname, './models_configuration/rust_models.js')}`])
+      .it('should handle configuration file', (ctx, done) => {
+        expect(ctx.stderr).toEqual('');
+        expect(ctx.stdout).toMatchSnapshot();
+        done();
+      });
   });
 
-  describe('for C#', () => {  
+  describe('for C#', () => {
     test
       .stderr()
       .stdout()
@@ -107,19 +157,29 @@ describe('models', () => {
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'csharp', './test/specification.yml', `-o=${ path.resolve(outputDir, './csharp')}`])
+      .command([...generalOptions, 'csharp', './test/specification.yml', `-o=${path.resolve(outputDir, './csharp')}`])
       .it('fails when no namespace provided', (ctx, done) => {
         expect(ctx.stderr).toEqual('Error: In order to generate models to C#, we need to know which namespace they are under. Add `--namespace=NAMESPACE` to set the desired namespace.\n');
         expect(ctx.stdout).toEqual('');
         done();
       });
-  });
 
-  describe('for Java', () => {  
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'java', './test/specification.yml', `-o=${ path.resolve(outputDir, './java')}`, '--packageName', 'test.package'])
+      .command([...generalOptions, 'csharp', './test/specification.yml', `-o=${path.resolve(outputDir, './ts_config')}`, '--namespace=\'test.namespace\'', `-c=${path.resolve(__dirname, './models_configuration/csharp_models.js')}`])
+      .it('should handle configuration file', (ctx, done) => {
+        expect(ctx.stderr).toEqual('');
+        expect(ctx.stdout).toMatchSnapshot();
+        done();
+      });
+  });
+
+  describe('for Java', () => {
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'java', './test/specification.yml', `-o=${path.resolve(outputDir, './java')}`, '--packageName', 'test.package'])
       .it('works when file path is passed', (ctx, done) => {
         expect(ctx.stderr).toEqual('');
         expect(ctx.stdout).toContain(
@@ -130,19 +190,29 @@ describe('models', () => {
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'java', './test/specification.yml', `-o=${ path.resolve(outputDir, './java')}`])
+      .command([...generalOptions, 'java', './test/specification.yml', `-o=${path.resolve(outputDir, './java')}`])
       .it('fails when no package defined', (ctx, done) => {
         expect(ctx.stderr).toEqual('Error: In order to generate models to Java, we need to know which package they are under. Add `--packageName=PACKAGENAME` to set the desired package name.\n');
         expect(ctx.stdout).toEqual('');
         done();
       });
-  });
 
-  describe('for Go', () => {  
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'golang', './test/specification.yml', `-o=${ path.resolve(outputDir, './go')}`, '--packageName', 'test.package'])
+      .command([...generalOptions, 'java', './test/specification.yml', `-o=${path.resolve(outputDir, './ts_config')}`, '--packageName=\'test.package\'', `-c=${path.resolve(__dirname, './models_configuration/java_models.js')}`])
+      .it('should handle configuration file', (ctx, done) => {
+        expect(ctx.stderr).toEqual('');
+        expect(ctx.stdout).toMatchSnapshot();
+        done();
+      });
+  });
+
+  describe('for Go', () => {
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'golang', './test/specification.yml', `-o=${path.resolve(outputDir, './go')}`, '--packageName', 'test.package'])
       .it('works when file path is passed', (ctx, done) => {
         expect(ctx.stderr).toEqual('');
         expect(ctx.stdout).toContain(
@@ -153,19 +223,28 @@ describe('models', () => {
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'golang', './test/specification.yml', `-o=${ path.resolve(outputDir, './go')}`])
+      .command([...generalOptions, 'golang', './test/specification.yml', `-o=${path.resolve(outputDir, './go')}`])
       .it('fails when no package defined', (ctx, done) => {
         expect(ctx.stderr).toEqual('Error: In order to generate models to Go, we need to know which package they are under. Add `--packageName=PACKAGENAME` to set the desired package name.\n');
         expect(ctx.stdout).toEqual('');
         done();
       });
-  });
-
-  describe('for Dart', () => {  
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'dart', './test/specification.yml', `-o=${ path.resolve(outputDir, './dart')}`, '--packageName', 'test.package'])
+      .command([...generalOptions, 'golang', './test/specification.yml', `-o=${path.resolve(outputDir, './ts_config')}`, '--packageName=\'test.package\'', `-c=${path.resolve(__dirname, './models_configuration/go_models.js')}`])
+      .it('should handle configuration file', (ctx, done) => {
+        expect(ctx.stderr).toEqual('');
+        expect(ctx.stdout).toMatchSnapshot();
+        done();
+      });
+  });
+
+  describe('for Dart', () => {
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'dart', './test/specification.yml', `-o=${path.resolve(outputDir, './dart')}`, '--packageName', 'test.package'])
       .it('works when file path is passed', (ctx, done) => {
         expect(ctx.stderr).toEqual('');
         expect(ctx.stdout).toContain(
@@ -176,10 +255,19 @@ describe('models', () => {
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'dart', './test/specification.yml', `-o=${ path.resolve(outputDir, './dart')}`])
+      .command([...generalOptions, 'dart', './test/specification.yml', `-o=${path.resolve(outputDir, './dart')}`])
       .it('fails when no package defined', (ctx, done) => {
         expect(ctx.stderr).toEqual('Error: In order to generate models to Dart, we need to know which package they are under. Add `--packageName=PACKAGENAME` to set the desired package name.\n');
         expect(ctx.stdout).toEqual('');
+        done();
+      });
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'dart', './test/specification.yml', `-o=${path.resolve(outputDir, './ts_config')}`, '--packageName=\'test.package\'', `-c=${path.resolve(__dirname, './models_configuration/dart_models.js')}`])
+      .it('should handle configuration file', (ctx, done) => {
+        expect(ctx.stderr).toEqual('');
+        expect(ctx.stdout).toMatchSnapshot();
         done();
       });
   });

--- a/test/commands/generate/models_configuration/csharp_models.js
+++ b/test/commands/generate/models_configuration/csharp_models.js
@@ -1,0 +1,17 @@
+const {JavaOptions, IndentationTypes} = require('@asyncapi/modelina');
+/** @type {JavaOptions} */
+module.exports = {
+  indentation: {
+    size: 10,
+    type: IndentationTypes.SPACES
+  },
+  constraints: {
+    modelName: (context) => {
+      return `Custom${context.modelName}`;
+    },
+    propertyKey: (context) => {
+      return `custom_prop_${context.objectPropertyModel.propertyName}`;
+    }
+  },
+  presets: [ ]
+}

--- a/test/commands/generate/models_configuration/dart_models.js
+++ b/test/commands/generate/models_configuration/dart_models.js
@@ -1,0 +1,17 @@
+const {JavaOptions, IndentationTypes} = require('@asyncapi/modelina');
+/** @type {JavaOptions} */
+module.exports = {
+  indentation: {
+    size: 10,
+    type: IndentationTypes.SPACES
+  },
+  constraints: {
+    modelName: (context) => {
+      return `Custom${context.modelName}`;
+    },
+    propertyKey: (context) => {
+      return `custom_prop_${context.objectPropertyModel.propertyName}`;
+    }
+  },
+  presets: [ ]
+}

--- a/test/commands/generate/models_configuration/go_models.js
+++ b/test/commands/generate/models_configuration/go_models.js
@@ -1,0 +1,17 @@
+const {JavaOptions, IndentationTypes} = require('@asyncapi/modelina');
+/** @type {JavaOptions} */
+module.exports = {
+  indentation: {
+    size: 10,
+    type: IndentationTypes.SPACES
+  },
+  constraints: {
+    modelName: (context) => {
+      return `Custom${context.modelName}`;
+    },
+    propertyKey: (context) => {
+      return `custom_prop_${context.objectPropertyModel.propertyName}`;
+    }
+  },
+  presets: [ ]
+}

--- a/test/commands/generate/models_configuration/incorrect_models.js
+++ b/test/commands/generate/models_configuration/incorrect_models.js
@@ -1,0 +1,12 @@
+const {TS_COMMON_PRESET} = require('@asyncapi/modelina');
+module.exports = {
+  presets: [
+    {
+      preset: TS_COMMON_PRESET,
+      options: {
+        example: true
+      }
+    }
+  ]
+}
+WRONG SYNTAX

--- a/test/commands/generate/models_configuration/java_models.js
+++ b/test/commands/generate/models_configuration/java_models.js
@@ -1,0 +1,23 @@
+const {JavaOptions, IndentationTypes} = require('@asyncapi/modelina');
+/** @type {JavaOptions} */
+module.exports = {
+  indentation: {
+    size: 10,
+    type: IndentationTypes.SPACES
+  },
+  constraints: {
+    modelName: (context) => {
+      return `Custom${context.modelName}`;
+    },
+    propertyKey: (context) => {
+      return `custom_prop_${context.objectPropertyModel.propertyName}`;
+    }
+  },
+  typeMapping: {
+    Any: (context) => {
+      // Always map AnyModel to object
+      return 'object';
+    }
+  },
+  presets: [ ]
+}

--- a/test/commands/generate/models_configuration/javascript_models.js
+++ b/test/commands/generate/models_configuration/javascript_models.js
@@ -1,0 +1,25 @@
+const {JS_COMMON_PRESET, JavaScriptOptions, IndentationTypes} = require('@asyncapi/modelina');
+/** @type {JavaScriptOptions} */
+module.exports = {
+  indentation: {
+    size: 10,
+    type: IndentationTypes.SPACES
+  },
+  moduleSystem: 'CJS',
+  constraints: {
+    modelName: (context) => {
+      return `Custom${context.modelName}`;
+    },
+    propertyKey: (context) => {
+      return `custom_prop_${context.objectPropertyModel.propertyName}`;
+    }
+  },
+  presets: [
+    {
+      preset: JS_COMMON_PRESET,
+      options: {
+        example: true
+      }
+    }
+  ]
+}

--- a/test/commands/generate/models_configuration/python_models.js
+++ b/test/commands/generate/models_configuration/python_models.js
@@ -1,0 +1,17 @@
+const {JavaOptions, IndentationTypes} = require('@asyncapi/modelina');
+/** @type {JavaOptions} */
+module.exports = {
+  indentation: {
+    size: 10,
+    type: IndentationTypes.SPACES
+  },
+  constraints: {
+    modelName: (context) => {
+      return `Custom${context.modelName}`;
+    },
+    propertyKey: (context) => {
+      return `custom_prop_${context.objectPropertyModel.propertyName}`;
+    }
+  },
+  presets: [ ]
+}

--- a/test/commands/generate/models_configuration/rust_models.js
+++ b/test/commands/generate/models_configuration/rust_models.js
@@ -1,0 +1,17 @@
+const {JavaOptions, IndentationTypes} = require('@asyncapi/modelina');
+/** @type {JavaOptions} */
+module.exports = {
+  indentation: {
+    size: 10,
+    type: IndentationTypes.SPACES
+  },
+  constraints: {
+    modelName: (context) => {
+      return `Custom${context.modelName}`;
+    },
+    propertyKey: (context) => {
+      return `custom_prop_${context.objectPropertyModel.propertyName}`;
+    }
+  },
+  presets: [ ]
+}

--- a/test/commands/generate/models_configuration/typescript_models.js
+++ b/test/commands/generate/models_configuration/typescript_models.js
@@ -1,0 +1,35 @@
+const {TS_COMMON_PRESET, TypeScriptOptions, IndentationTypes} = require('@asyncapi/modelina');
+/** @type {TypeScriptOptions} */
+module.exports = {
+  enumType: 'union',
+  modelType: 'interface',
+  indentation: {
+    size: 10,
+    type: IndentationTypes.SPACES
+  },
+  mapType: 'record',
+  renderTypes: false,
+  moduleSystem: 'CJS',
+  constraints: {
+    modelName: (context) => {
+      return `Custom${context.modelName}`;
+    },
+    propertyKey: (context) => {
+      return `custom_prop_${context.objectPropertyModel.propertyName}`;
+    }
+  },
+  typeMapping: {
+    Any: (context) => {
+      // Always map AnyModel to number
+      return 'number';
+    }
+  },
+  presets: [
+    {
+      preset: TS_COMMON_PRESET,
+      options: {
+        example: true
+      }
+    }
+  ]
+}

--- a/test/specification.yml
+++ b/test/specification.yml
@@ -12,12 +12,15 @@ components:
   messages:
     UserSignedUp:
       payload:
-        type: object
-        properties:
-          displayName:
-            type: string
-            description: Name of the user
-          email:
-            type: string
-            format: email
-            description: Email of the user
+        $ref: '#/components/schemas/UserSignedUpPayload'
+  schemas:
+    UserSignedUpPayload:
+      type: object
+      properties:
+        displayName:
+          type: string
+          description: Name of the user
+        email:
+          type: string
+          format: email
+          description: Email of the user


### PR DESCRIPTION
**Description**
Currently, it's hard to utilize the full feature suite of Modelina, because they are hidden behind callbacks (to allow full customization of model rendering). To enable these features we need to support a basic configuration file, that the user can use to customize the model generation phase when running the `asyncapi generate models` command.

This PR is just a proof of concept to be used for discussing how to proceed.

To enable the configuration file a user can do the following:
```
asyncapi generate models typescript -c="./typescript_model.js"
```

Where the configuration file is:
```js
const {TS_COMMON_PRESET, TypeScriptOptions, IndentationTypes} = require('@asyncapi/modelina');
/** @type {TypeScriptOptions} */
module.exports = {
  enumType: 'union',
  modelType: 'interface',
  indentation: {
    size: 10,
    type: IndentationTypes.SPACES
  },
  mapType: 'record',
  renderTypes: false,
  moduleSystem: 'CJS',
  constraints: {
    modelName: (context) => {
      return `Custom${context.modelName}`;
    },
    propertyKey: (context) => {
      return `custom_prop_${context.objectPropertyModel.propertyName}`;
    }
  },
  typeMapping: {
    Any: (context) => {
      // Always map AnyModel to number
      return 'number';
    }
  },
  presets: [
    {
      preset: TS_COMMON_PRESET,
      options: {
        example: true
      }
    }
  ]
}
```

This gives 100% control of the generators to the user.

**Related issue(s)**
Related to https://github.com/asyncapi/modelina/issues/780