### PR TITLE
feat: change the collectionType for arrays for C# models

### DIFF
--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -82,12 +82,19 @@ export default class Models extends Command {
       description: 'C# specific, define the namespace to use for the generated models. This is required when language is `csharp`.',
       required: false
     }),
+    csharpArrayType: Flags.string({
+      type: 'option',
+      description: 'C# specific, define which type of array needs to be generated. This is required when language is `csharp`.',
+      options: ['Array', 'List'],
+      required: false,
+      default: 'Array',
+    }),
     ...validationFlags({ logDiagnostics: false }),
   };
 
   async run() {
     const { args, flags } = await this.parse(Models);
-    const { tsModelType, tsEnumType, tsModuleSystem, tsExportType, namespace, packageName, output } = flags;
+    const { tsModelType, tsEnumType, tsModuleSystem, tsExportType, namespace, csharpArrayType, packageName, output } = flags;
     const { language, file } = args;
 
     const inputFile = (await load(file)) || (await load());
@@ -134,7 +141,9 @@ export default class Models extends Command {
       if (namespace === undefined) {
         throw new Error('In order to generate models to C#, we need to know which namespace they are under. Add `--namespace=NAMESPACE` to set the desired namespace.');
       }
-      fileGenerator = new CSharpFileGenerator();
+      fileGenerator = new CSharpFileGenerator({
+        collectionType: csharpArrayType as 'Array' | 'List'
+      });
       fileOptions = {
         namespace
       };

--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -84,7 +84,7 @@ export default class Models extends Command {
     }),
     csharpArrayType: Flags.string({
       type: 'option',
-      description: 'C# specific, define which type of array needs to be generated. This is required when language is `csharp`.',
+      description: 'C# specific, define which type of array needs to be generated.',
       options: ['Array', 'List'],
       required: false,
       default: 'Array',

--- a/test/commands/generate/models.test.ts
+++ b/test/commands/generate/models.test.ts
@@ -113,6 +113,17 @@ describe('models', () => {
         expect(ctx.stdout).toEqual('');
         done();
       });
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'csharp', './test/specification.yml', `-o=${ path.resolve(outputDir, './csharp')}`, '--namespace=\'asyncapi.models\' --csharpArrayType=\'List\'']) 
+      .it('works when array type is provided', (ctx, done) => {
+        expect(ctx.stderr).toEqual('');
+        expect(ctx.stdout).toContain(
+          'Successfully generated the following models: '
+        );
+        done();
+      });
   });
 
   describe('for Java', () => {

--- a/test/commands/generate/models.test.ts
+++ b/test/commands/generate/models.test.ts
@@ -116,7 +116,7 @@ describe('models', () => {
     test
       .stderr()
       .stdout()
-      .command([...generalOptions, 'csharp', './test/specification.yml', `-o=${ path.resolve(outputDir, './csharp')}`, '--namespace=\'asyncapi.models\' --csharpArrayType=\'List\'']) 
+      .command([...generalOptions, 'csharp', './test/specification.yml', `-o=${ path.resolve(outputDir, './csharp')}`, '--namespace=\'asyncapi.models\'', '--csharpArrayType=List']) 
       .it('works when array type is provided', (ctx, done) => {
         expect(ctx.stderr).toEqual('');
         expect(ctx.stdout).toContain(


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Add `csharpArrayType` flag to pass collection type for C# models.
- Added test case for the same.
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #469 