### PR TITLE
fix: adjust release pipeline to node 18

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -46,9 +46,9 @@ jobs:
         shell: bash
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - if: steps.packagejson.outputs.exists == 'true'


### PR DESCRIPTION
Since we did https://github.com/asyncapi/cli/pull/501/files#diff-fd411b4d11d3f5d1d4406fc43b9696941eaec0a37f53b34e04cd1adac4b8e193 we also need to adjust release workflow as it won't pass