### PR TITLE
fix: workflow for windows assets download

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -49,8 +49,13 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - name: Get version from package.json
+        uses: actions/github-script@v6
         id: extractver
-        run: echo "::set-output name=version::$(npm run get-version --silent)"
+        with:
+          script: |
+            const packageJson = require('./package.json');
+            const packageJsonVersion = packageJson.version;
+            core.setOutput('version', packageJsonVersion);
       - name: Install dependencies
         run: npm install
       - name: Build project


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR is updating the `upload-release-assets` workflow because it had issues with windows assets generation, which started due to `echo $npm_package_version`not working in windows. 
