### PR TITLE
fix: windows installer asset uploads

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -49,8 +49,13 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - name: Get version from package.json
+        uses: actions/github-script@v6
         id: extractver
-        run: echo "::set-output name=version::$(npm run get-version --silent)"
+        with:
+          script: |
+            const packageJson = require('./package.json');
+            const packageJsonVersion = packageJson.version;
+            core.setOutput('version', packageJsonVersion);
       - name: Install dependencies
         run: npm install
       - name: Build project

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "pack:macos": "oclif pack macos && npm run pack:rename",
     "pack:linux": "oclif pack deb && npm run pack:rename",
     "pack:tarballs": "oclif pack tarballs -t linux-x64 && npm run pack:rename",
-    "pack:windows": "oclif pack win",
+    "pack:windows": "oclif pack win && npm run pack:rename",
     "pack:rename": "node scripts/releasePackagesRename.js",
     "postpack": "rimraf oclif.manifest.json",
     "prepublishOnly": "npm run build && oclif manifest",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Was missing the command to rename script from the `package.json` file. 

