### PR TITLE
feat: add typescript marshalling function generation support

### DIFF
--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -82,6 +82,11 @@ export default class Models extends Command {
       required: false,
       default: false,
     }),
+    tsMarshalling: Flags.boolean({
+      description: 'TypeScript specific, generate the models with marshalling functions.',
+      required: false,
+      default: false,
+    }),
     /**
      * Go and Java specific package name to use for the generated models
      */
@@ -139,7 +144,7 @@ export default class Models extends Command {
   /* eslint-disable sonarjs/cognitive-complexity */
   async run() {
     const { args, flags } = await this.parse(Models);
-    const { tsModelType, tsEnumType, tsIncludeComments, tsModuleSystem, tsExportType, tsJsonBinPack, namespace, csharpAutoImplement, csharpArrayType, csharpNewtonsoft, csharpHashcode, csharpEqual, csharpSystemJson, packageName, output } = flags;
+    const { tsModelType, tsEnumType, tsIncludeComments, tsModuleSystem, tsExportType, tsJsonBinPack, tsMarshalling, namespace, csharpAutoImplement, csharpArrayType, csharpNewtonsoft, csharpHashcode, csharpEqual, csharpSystemJson, packageName, output } = flags;
     const { language, file } = args;
     const inputFile = (await load(file)) || (await load());
     const { document, status } = await parse(this, inputFile, flags);
@@ -176,6 +181,14 @@ export default class Models extends Command {
           }
         },
         TS_JSONBINPACK_PRESET);
+      }
+      if (tsMarshalling) {
+        presets.push({
+          preset: TS_COMMON_PRESET,
+          options: {
+            marshalling: true
+          }
+        });
       }
       fileGenerator = new TypeScriptFileGenerator({
         modelType: tsModelType as 'class' | 'interface',

--- a/test/commands/generate/models.test.ts
+++ b/test/commands/generate/models.test.ts
@@ -61,6 +61,17 @@ describe('models', () => {
     test
       .stderr()
       .stdout()
+      .command([...generalOptions, 'typescript', './test/specification.yml', '--tsMarshalling'])
+      .it('works when tsMarshalling is set', (ctx, done) => {
+        expect(ctx.stderr).toEqual('');
+        expect(ctx.stdout).toContain(
+          'Successfully generated the following models: '
+        );
+        done();
+      });
+    test
+      .stderr()
+      .stdout()
       .command([...generalOptions, 'typescript', './test/specification.yml', '--tsIncludeComments'])
       .it('works when tsIncludeComments is set', (ctx, done) => {
         expect(ctx.stderr).toEqual('');


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- add flag `tsMarshalling` to generate marshalling functions for typescript.

**Related issue(s)**
Fixes #460 