### PR TITLE
fix: make sure that cli commands generation builds project

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
     "dev": "tsc --watch",
     "generate:readme:create": "printf '\n\n# Usage\n\n<!-- usage -->\n\n# Commands\n\n<!-- commands -->\n' > scripts/README.md",
-    "generate:readme:commands": "cd scripts && DEBUG=* oclif readme",
+    "generate:readme:commands": "npm run build && cd scripts && DEBUG=* oclif readme",
     "generate:assets": "npm run generate:readme:toc && npm run generate:commands",
     "generate:commands": "npm run generate:readme:create && npm run generate:readme:commands && node ./scripts/updateUsageDocs.js && rimraf ./scripts/README.md",
     "generate:readme:toc": "markdown-toc -i README.md",


### PR DESCRIPTION
related to https://github.com/asyncapi/cli/issues/123#issuecomment-1568505343

all work done by @mhmohona was great, we just forgot that by config it is looking for commands in `/home/runner/work/cli/cli/lib/commands` but `lib` is a folder that is not in repo, it needs to be build with `npm run build`

making it as fix as also recent release was broken because of it we assets were not uploaded