### PR TITLE
feat: helper message for `invalid` specification file during model generation

### DIFF
--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -2,7 +2,7 @@ import { CSharpFileGenerator, JavaFileGenerator, JavaScriptFileGenerator, TypeSc
 import { Flags } from '@oclif/core';
 import Command from '../../base';
 import { load } from '../../models/SpecificationFile';
-import { parse, validationFlags } from '../../parser';
+import { formatOutput, parse, validationFlags } from '../../parser';
 
 import type { AbstractGenerator, AbstractFileGenerator } from '@asyncapi/modelina';
 
@@ -142,8 +142,10 @@ export default class Models extends Command {
     const { tsModelType, tsEnumType, tsIncludeComments, tsModuleSystem, tsExportType, tsJsonBinPack, namespace, csharpAutoImplement, csharpArrayType, csharpNewtonsoft, csharpHashcode, csharpEqual, csharpSystemJson, packageName, output } = flags;
     const { language, file } = args;
     const inputFile = (await load(file)) || (await load());
-    const { document, status } = await parse(this, inputFile, flags);
+    const { document, diagnostics ,status } = await parse(this, inputFile, flags);
     if (!document || status === 'invalid') {
+      const severityErrors = diagnostics.filter((obj) => obj.severity === 0);
+      this.log(`Input is an empty file or not a correct AsyncAPI document so it cannot be processed.${formatOutput(severityErrors,'stylish','error')}`);
       return;
     }
 

--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -145,7 +145,7 @@ export default class Models extends Command {
     const { document, diagnostics ,status } = await parse(this, inputFile, flags);
     if (!document || status === 'invalid') {
       const severityErrors = diagnostics.filter((obj) => obj.severity === 0);
-      this.log(`Input is an empty file or not a correct AsyncAPI document so it cannot be processed.${formatOutput(severityErrors,'stylish','error')}`);
+      this.log(`Input is not a correct AsyncAPI document so it cannot be processed.${formatOutput(severityErrors,'stylish','error')}`);
       return;
     }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -80,7 +80,6 @@ function logDiagnostics(diagnostics: Diagnostic[], command: Command, specFile: S
         command.logToStderr(`\n${sourceString} and/or referenced documents have governance issues.`);
         command.logToStderr(formatOutput(diagnostics, diagnosticsFormat, failSeverity));
       }
-      command.exit(1);
       return 'invalid';
     }
 
@@ -95,7 +94,7 @@ function logDiagnostics(diagnostics: Diagnostic[], command: Command, specFile: S
   return 'valid';
 }
 
-function formatOutput(diagnostics: Diagnostic[], format: `${OutputFormat}`, failSeverity: SeveritytKind) {
+export function formatOutput(diagnostics: Diagnostic[], format: `${OutputFormat}`, failSeverity: SeveritytKind) {
   const options = { failSeverity: getDiagnosticSeverity(failSeverity) };
   switch (format) {
   case 'stylish': return stylish(diagnostics, options);


### PR DESCRIPTION
**Description**

- Added error logging for invalid specification file

![image](https://github.com/asyncapi/cli/assets/112387862/1ed4bf63-3edd-4c00-adbb-6dfb18634755)


**Related issue(s)**
Resolves #616 
Fixes https://github.com/asyncapi/cli/issues/549