### PR TITLE
feat: diff will show error on breaking changes

### DIFF
--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -8,6 +8,7 @@ import Command from '../base';
 import { ValidationError } from '../errors/validation-error';
 import { SpecificationFileNotFound } from '../errors/specification-file';
 import {
+  DiffBreakingChangeError,
   DiffOverrideFileError,
   DiffOverrideJSONError,
 } from '../errors/diff-error';
@@ -40,6 +41,9 @@ export default class Diff extends Command {
       char: 'o',
       description: 'path to JSON file containing the override properties',
     }),
+    'no-error': Flags.boolean({
+      description: 'don\'t show error on breaking changes',
+    }),
     watch: watchFlag(),
     ...validationFlags({ logDiagnostics: false }),
   };
@@ -57,6 +61,7 @@ export default class Diff extends Command {
     },
   ];
 
+  /* eslint-disable sonarjs/cognitive-complexity */
   async run() {
     const { args, flags } = await this.parse(Diff); // NOSONAR
     const firstDocumentPath = args['old'];
@@ -66,6 +71,7 @@ export default class Diff extends Command {
     const outputType = flags['type'];
     const overrideFilePath = flags['overrides'];
     const watchMode = flags['watch'];
+    const noError = flags['no-error'];
     let firstDocument: Specification, secondDocument: Specification;
 
     try {
@@ -143,7 +149,13 @@ export default class Diff extends Command {
           `The output format ${outputFormat} is not supported at the moment.`
         );
       }
+      if (!noError) {
+        throwOnBreakingChange(diffOutput);
+      }
     } catch (error) {
+      if (error instanceof DiffBreakingChangeError) {
+        throw error;
+      } 
       throw new ValidationError({
         type: 'parser-error',
         err: error,
@@ -222,3 +234,13 @@ const enableWatch = (status: boolean, watcher: SpecWatcherParams) => {
     specWatcher(watcher);
   }
 };
+
+/**
+ * Throws `DiffBreakingChangeError` when breaking changes are detected
+ */
+function throwOnBreakingChange(diffOutput: AsyncAPIDiff) {
+  const breakingChanges = diffOutput.breaking();
+  if (breakingChanges.length !== 0) {
+    throw new DiffBreakingChangeError();
+  }
+}

--- a/src/errors/diff-error.ts
+++ b/src/errors/diff-error.ts
@@ -13,3 +13,11 @@ export class DiffOverrideJSONError extends Error {
     this.message = 'Provided override file is not a valid JSON file';
   }
 }
+
+export class DiffBreakingChangeError extends Error {
+  constructor() {
+    super();
+    this.name = 'DiffBreakingChangeError';
+    this.message = 'Breaking changes detected';
+  }
+}

--- a/test/commands/diff.test.ts
+++ b/test/commands/diff.test.ts
@@ -28,6 +28,7 @@ describe('diff', () => {
         './test/fixtures/asyncapi_v2.yml',
         '--type=all',
         '--format=json',
+        '--no-error',
       ])
       .it('works when file path is passed', (ctx, done) => {
         expect(JSON.stringify(ctx.stdout)).toEqual(
@@ -48,6 +49,7 @@ describe('diff', () => {
         './test/fixtures/asyncapi_v2.yml',
         '--type=breaking',
         '--format=json',
+        '--no-error',
       ])
       .it('works when file path is passed', (ctx, done) => {
         expect(JSON.stringify(ctx.stdout)).toEqual(
@@ -68,6 +70,7 @@ describe('diff', () => {
         './test/fixtures/asyncapi_v2.yml',
         '--type=non-breaking',
         '--format=json',
+        '--no-error',
       ])
       .it('works when file path is passed', (ctx, done) => {
         expect(JSON.stringify(ctx.stdout)).toEqual(
@@ -88,6 +91,7 @@ describe('diff', () => {
         './test/fixtures/asyncapi_v2.yml',
         '--type=unclassified',
         '--format=json',
+        '--no-error',
       ])
       .it('works when file path is passed', (ctx, done) => {
         expect(JSON.stringify(ctx.stdout)).toEqual(
@@ -107,6 +111,7 @@ describe('diff', () => {
         './test/fixtures/asyncapi_v1.yml',
         './test/fixtures/asyncapi_v2.yml',
         '--format=json',
+        '--no-error',
       ])
       // eslint-disable-next-line sonarjs/no-identical-functions
       .it('works when file path is passed', (ctx, done) => {
@@ -128,6 +133,7 @@ describe('diff', () => {
         './test/fixtures/asyncapi_v2.yml',
         '--overrides=./test/fixtures/overrides.json',
         '--format=json',
+        '--no-error',
       ])
       .it((ctx, done) => {
         expect(JSON.stringify(ctx.stdout)).toEqual(
@@ -186,12 +192,31 @@ describe('diff', () => {
         './test/fixtures/asyncapi_v1.yml',
         './test/fixtures/asyncapi_v2.yml',
         '--type=all',
+        '--no-error',
       ])
       .it('works when file path is passed', (ctx, done) => {
         expect(JSON.stringify(ctx.stdout)).toEqual(
           '"changes:\\n  - action: edit\\n    path: >-\\n      /channels/light~1measured/publish/message/x-parser-original-payload/properties/id/minimum\\n    before: 0\\n    after: 1\\n    type: unclassified\\n  - action: edit\\n    path: /channels/light~1measured/publish/message/payload/properties/id/minimum\\n    before: 0\\n    after: 1\\n    type: unclassified\\n  - action: edit\\n    path: /servers/mosquitto/protocol\\n    before: mqtt\\n    after: http\\n    type: unclassified\\n  - action: edit\\n    path: /servers/mosquitto/url\\n    before: mqtt://test.mosquitto.org\\n    after: http://test.mosquitto.org\\n    type: breaking\\n  - action: edit\\n    path: /info/title\\n    before: Streetlights API\\n    after: Streetlights API V2\\n    type: non-breaking\\n\\n"'
         );
         expect(ctx.stderr).toEqual('');
+        done();
+      });
+  });
+
+  describe('should show error on breaking changes', () => {
+    test
+      .stderr()
+      .stdout()
+      .command([
+        'diff',
+        './test/fixtures/asyncapi_v1.yml',
+        './test/fixtures/asyncapi_v2.yml',
+      ])
+      .it('works when file path is passed', (ctx, done) => {
+        expect(JSON.stringify(ctx.stdout)).toEqual(
+          '"changes:\\n  - action: edit\\n    path: >-\\n      /channels/light~1measured/publish/message/x-parser-original-payload/properties/id/minimum\\n    before: 0\\n    after: 1\\n    type: unclassified\\n  - action: edit\\n    path: /channels/light~1measured/publish/message/payload/properties/id/minimum\\n    before: 0\\n    after: 1\\n    type: unclassified\\n  - action: edit\\n    path: /servers/mosquitto/protocol\\n    before: mqtt\\n    after: http\\n    type: unclassified\\n  - action: edit\\n    path: /servers/mosquitto/url\\n    before: mqtt://test.mosquitto.org\\n    after: http://test.mosquitto.org\\n    type: breaking\\n  - action: edit\\n    path: /info/title\\n    before: Streetlights API\\n    after: Streetlights API V2\\n    type: non-breaking\\n\\n"'
+        );
+        expect(ctx.stderr).toEqual('DiffBreakingChangeError: Breaking changes detected\n');
         done();
       });
   });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

`diff` command will now show error(with exit code 1) when breaking changes are detected. This is the default behaviour.
There's also a flag `--no-error` you can provide to not show this error.
Ex.
```
diff ./old.yml ./new.yml --no-error
```

The current behaviour is that diff will show error no matter the `type` of changes required. For example, 
```
diff ./old.yml ./new.yml --type=non-breaking
```
will show a breaking change error in case there are breaking changes detected between provided documents. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
None