### PR TITLE
fix: issue with bundle command

### DIFF
--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -57,7 +57,7 @@ export default class Bundle extends Command {
       }
 
       if (format === '.json') {
-        await writeFile(path.resolve(process.cwd(), output), document.json(), {
+        await writeFile(path.resolve(process.cwd(), output), document.string(), {
           encoding: 'utf-8',
         });
       }

--- a/test/commands/bundle/bundle.test.ts
+++ b/test/commands/bundle/bundle.test.ts
@@ -34,10 +34,10 @@ describe('bundle', () => {
     .it('should successfully bundle specification into json file', (ctx, done) => {
       expect(ctx.stdout).toContain(
         'Check out your shiny new bundled files at ./test/commands/bundle/final.json'
-      )
-      fileCleanup('./test/commands/bundle/final.json')
-      done()
-    })
+      );
+      fileCleanup('./test/commands/bundle/final.json');
+      done();
+    });
 
   test
     .stderr()

--- a/test/commands/bundle/bundle.test.ts
+++ b/test/commands/bundle/bundle.test.ts
@@ -26,6 +26,20 @@ describe('bundle', () => {
     });
 
   test
+    .stdout()
+    .command([
+      'bundle', './test/commands/bundle/first-asyncapi.yaml',
+      '--output=./test/commands/bundle/final.json'
+    ])
+    .it('should successfully bundle specification into json file', (ctx, done) => {
+      expect(ctx.stdout).toContain(
+        'Check out your shiny new bundled files at ./test/commands/bundle/final.json'
+      )
+      fileCleanup('./test/commands/bundle/final.json')
+      done()
+    })
+
+  test
     .stderr()
     .command([
       'bundle', './test/commands/bundle/asyncapi.yml'


### PR DESCRIPTION
bundle command was unable to output in json format.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

The `bundle` command was unable to export to `.json` format as `document.json` returns an object instead of a string. 

https://github.com/asyncapi/cli/blob/a874a1a065cae54b30e20bb1485ca63c1a87427b/src/commands/bundle.ts#L60

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

Fixes #699 