### PR TITLE
feat: add flag to set context when it is created

### DIFF
--- a/src/commands/config/context/add.ts
+++ b/src/commands/config/context/add.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core';
 import Command from '../../../base';
-import { addContext } from '../../../models/Context';
+import { addContext, setCurrentContext } from '../../../models/Context';
 import {
   MissingContextFileError,
   ContextFileWrongFormatError,
@@ -10,6 +10,12 @@ export default class ContextAdd extends Command {
   static description = 'Add a context to the store';
   static flags = {
     help: Flags.help({ char: 'h' }),
+    'set-current': Flags.boolean({
+      char: 's',
+      description: 'Set context being added as the current context',
+      default: false,
+      required: false,
+    })
   };
 
   static args = [
@@ -22,15 +28,23 @@ export default class ContextAdd extends Command {
   ];
 
   async run() {
-    const { args } = await this.parse(ContextAdd);
+    const { args, flags } = await this.parse(ContextAdd);
     const contextName = args['context-name'];
     const specFilePath = args['spec-file-path'];
+    const setAsCurrent = flags['set-current'];
 
     try {
       await addContext(contextName, specFilePath);
       this.log(
         `Added context "${contextName}".\n\nYou can set it as your current context: asyncapi config context use ${contextName}\nYou can use this context when needed by passing ${contextName} as a parameter: asyncapi validate ${contextName}`
       );
+
+      if (setAsCurrent) {
+        await setCurrentContext(contextName);
+        this.log(
+          `The newly added context "${contextName}", is set as your current context!`
+        );
+      }
     } catch (e) {
       if (
         e instanceof (MissingContextFileError || ContextFileWrongFormatError)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Adds a new flag `--set-current` / `-s` to the context add command that sets the context on addition
- Tested locally by building the cli
  
![image](https://github.com/asyncapi/cli/assets/79566582/8973ebb9-8d66-4474-a3ff-efd489bf1327)

**Related issue(s)**
Resolves #726 
See also #751 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->