### PR TITLE
feat: add flag 'd' for context add command to print any errors caught

### DIFF
--- a/src/commands/config/context/add.ts
+++ b/src/commands/config/context/add.ts
@@ -10,6 +10,12 @@ export default class ContextAdd extends Command {
   static description = 'Add a context to the store';
   static flags = {
     help: Flags.help({ char: 'h' }),
+    debug: Flags.boolean({
+      char: 'd',
+      description: 'Print any errors that arise',
+      default: false,
+      required: false,
+    })
   };
 
   static args = [
@@ -22,9 +28,10 @@ export default class ContextAdd extends Command {
   ];
 
   async run() {
-    const { args } = await this.parse(ContextAdd);
+    const { args, flags } = await this.parse(ContextAdd);
     const contextName = args['context-name'];
     const specFilePath = args['spec-file-path'];
+    const debugFlag = flags['debug'];
 
     try {
       await addContext(contextName, specFilePath);
@@ -32,6 +39,10 @@ export default class ContextAdd extends Command {
         `Added context "${contextName}".\n\nYou can set it as your current context: asyncapi config context use ${contextName}\nYou can use this context when needed by passing ${contextName} as a parameter: asyncapi validate ${contextName}`
       );
     } catch (e) {
+      if(debugFlag){
+        this.log(`---DEBUGGING INFO---\n\n`,e,`\n\n---END DEBUGGING INFO---\n`);
+      }
+
       if (
         e instanceof (MissingContextFileError || ContextFileWrongFormatError)
       ) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- add `--debug` / `-d` flag that prints any errors completely that are caught in the catch block.
``` 
BEFORE THE CHANGE
$ .\bin\run config context add foo .\asyncapi.yaml
You have no context file configured. Run "asyncapi config context init" to initialize it.

AFTER THE CHANGE
$ .\bin\run config context add foo .\asyncapi.yaml --debug
---DEBUGGING INFO---

 MissingContextFileError [ContextError]: These are your options to specify in the CLI what AsyncAPI file should be used:
        - You can provide a path to the AsyncAPI file: asyncapi <command> path/to/file/asyncapi.yml
        - You can provide URL to the AsyncAPI file: asyncapi <command> https://example.com/path/to/file/asyncapi.yml
        - You can also pass a saved context that points to your AsyncAPI file: asyncapi <command> context-name
        - In case you did not specify a context that you want to use, the CLI checks if there is a default context and uses it. To set default context run: asyncapi config context use mycontext
        - In case you did not provide any reference to AsyncAPI file and there is no default context, the CLI detects if in your current working directory you have files like asyncapi.json, asyncapi.yaml, asyncapi.yml. Just rename your file accordingly.

    at C:\Anish\Code\cli\lib\models\Context.js:198:19
    at Generator.throw (<anonymous>)
    at rejected (C:\Anish\Code\cli\node_modules\tslib\tslib.js:165:69)

---END DEBUGGING INFO---

You have no context file configured. Run "asyncapi config context init" to initialize it.
 ```


**Related issue(s)**
See also #751 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->