### PR TITLE
fix: read context file sync way when calling context model

### DIFF
--- a/.asyncapi-cli
+++ b/.asyncapi-cli
@@ -1,0 +1,1 @@
+{"store":{"dummy":"test/fixtures/dummy.yml"}}

--- a/.asyncapi-cli
+++ b/.asyncapi-cli
@@ -1,1 +1,0 @@
-{"store":{"dummy":"test/fixtures/dummy.yml"}}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,5 @@ asyncapi.json
 asyncapi.yml
 test/minimaltemplate/__transpiled
 .vscode
-
-
+oclif.manifest.json
 spec-examples.zip

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   },
   "repository": "asyncapi/cli",
   "scripts": {
-    "build": "rimraf lib && node scripts/fetch-asyncapi-example.js && tsc && echo \"Build Completed\"",
+    "build": "rimraf lib && node scripts/fetch-asyncapi-example.js && tsc && oclif manifest && echo \"Build Completed\"",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
     "dev": "tsc --watch",
     "docker:build": "docker build -t asyncapi/cli:latest .",
@@ -143,8 +143,7 @@
     "pack:tarballs": "oclif pack tarballs -t linux-x64 && npm run pack:rename",
     "pack:windows": "oclif pack win && npm run pack:rename",
     "pack:rename": "node scripts/releasePackagesRename.js",
-    "postpack": "rimraf oclif.manifest.json",
-    "prepublishOnly": "npm run build && oclif manifest",
+    "prepublishOnly": "npm run build",
     "pretest:coverage": "npm run build",
     "release": "semantic-release",
     "pretest": "npm run build",

--- a/src/models/Context.ts
+++ b/src/models/Context.ts
@@ -1,4 +1,4 @@
-import { promises as fs, existsSync, lstatSync } from 'fs';
+import { readFileSync, promises as fs, existsSync, lstatSync } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
@@ -318,7 +318,7 @@ async function getContextFilePath(): Promise<string | null> {
 
   for (let i = currentPath.length; i >= 0; i--) {
     const currentPathString = currentPath[0]
-      ? currentPath.join(path.sep) + path.sep + CONTEXT_FILENAME
+      ? currentPath.join(path.sep) + CONTEXT_FILENAME
       : os.homedir() + path.sep + CONTEXT_FILENAME;
 
     // This `try...catch` is a part of `for` loop and is used only to swallow
@@ -329,9 +329,7 @@ async function getContextFilePath(): Promise<string | null> {
       // legitimate context file, then it is considered a legitimate context
       // file indeed.
       const fileContent = JSON.parse(
-        await readFile(currentPathString, {
-          encoding: 'utf8',
-        })
+        readFileSync(currentPathString, {encoding: 'utf8'})
       );
       if (
         fileContent &&

--- a/src/models/Context.ts
+++ b/src/models/Context.ts
@@ -318,7 +318,7 @@ async function getContextFilePath(): Promise<string | null> {
 
   for (let i = currentPath.length; i >= 0; i--) {
     const currentPathString = currentPath[0]
-      ? currentPath.join(path.sep) + CONTEXT_FILENAME
+      ? currentPath.join(path.sep) + path.sep + CONTEXT_FILENAME
       : os.homedir() + path.sep + CONTEXT_FILENAME;
 
     // This `try...catch` is a part of `for` loop and is used only to swallow

--- a/src/models/Context.ts
+++ b/src/models/Context.ts
@@ -329,6 +329,7 @@ async function getContextFilePath(): Promise<string | null> {
       // legitimate context file, then it is considered a legitimate context
       // file indeed.
       const fileContent = JSON.parse(
+        //we do not use await readFile because getContextFilePath cannot be called inside async function
         readFileSync(currentPathString, {encoding: 'utf8'})
       );
       if (


### PR DESCRIPTION
Fixes https://github.com/asyncapi/cli/issues/751

- now `oclif.manifest.json` is also generated on local. Git ignored, but it will be published to npm as it is explicitly mentioned in package.json `files`
- we read context file using node sync method as the parent function cannot run inside `async` function