### PR TITLE
chore: adjust workflows to follow latest gh actions requirements

### DIFF
--- a/.github/workflows/bump-homebrew-formula.yml
+++ b/.github/workflows/bump-homebrew-formula.yml
@@ -23,13 +23,15 @@ jobs:
         with:
           # A PR will be sent to github.com/Homebrew/homebrew-core to update AsyncAPI CLI formula:
           formula-name: asyncapi
+          # https://github.com/mislav/bump-homebrew-formula-action/issues/58
+          formula-path: Formula/a/asyncapi.rb
           tag-name: ${{ steps.extractver.outputs.version }}
           download-url: https://registry.npmjs.org/@asyncapi/cli/-/cli-${{ steps.extractver.outputs.version }}.tgz #we need to point to npm not github as there is a dist that is not on github
         env:
           COMMITTER_TOKEN: ${{ secrets.GH_TOKEN_BOT_EVE }}
       - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@fbd6aa58ba854a740e11a35d0df80cb5d12101d8 #using https://github.com/8398a7/action-slack/releases/tag/v3.15.1
         with:
           status: ${{ job.status }}
           fields: repo,action,workflow

--- a/.github/workflows/update-docs-in-website.yml
+++ b/.github/workflows/update-docs-in-website.yml
@@ -15,11 +15,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Checkout Current repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: cli
       - name: Checkout Another repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: asyncapi/website
           path: website

--- a/.github/workflows/update-docs-on-docs-commits.yml
+++ b/.github/workflows/update-docs-on-docs-commits.yml
@@ -15,17 +15,19 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+      - name: Check package-lock version
+        uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: "${{ steps.lockversion.outputs.version }}"
       - name: Install dependencies
         run: npm ci
       - name: Regenerate docs
         run: npm run generate:assets --if-present
       - name: Create Pull Request with updated docs
         if: startsWith(github.event.commits[0].message, 'docs:')
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # use 4.2.4 https://github.com/peter-evans/create-pull-request/releases/tag/v4.2.4
         with:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: 'chore: update generated docs'

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -42,10 +42,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Check package-lock version
+        uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
+        id: lockversion
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: "${{ steps.lockversion.outputs.version }}"
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - name: Get version from package.json
@@ -70,7 +73,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
       - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@fbd6aa58ba854a740e11a35d0df80cb5d12101d8 #using https://github.com/8398a7/action-slack/releases/tag/v3.15.1
         with:
           status: ${{ job.status }}
           fields: repo,action,workflow


### PR DESCRIPTION
1. resolves https://github.com/asyncapi/cli/issues/605. One left is https://github.com/asyncapi/cli/pull/675/
2.  solves issues with brew publishing that do not work last 3 weeks https://github.com/asyncapi/cli/actions/runs/6030940883