### PR TITLE
fix: add @types/node to package.json

### DIFF
--- a/assets/create-glee-app/templates/default/package.json
+++ b/assets/create-glee-app/templates/default/package.json
@@ -25,5 +25,8 @@
   "homepage": "https://github.com/asyncapi/glee-hello-world#readme",
   "dependencies": {
     "@asyncapi/glee": "^0.26.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.5.9"
   }
 }


### PR DESCRIPTION
**Description**

The current project generated with `asyncapi new glee` is not working because it's missing the `@types/node` dependency. I'm adding it.

**Related issue(s)**
No issue