### PR TITLE
feat: improve the log and correct the path name using optimise command

### DIFF
--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -99,12 +99,10 @@ export default class Optimize extends Command {
 
       const specPath = specFile.getFilePath();
       let newPath = '';
-      let originalPath = '';
-
+      
       if (specPath) {
         const pos = specPath.lastIndexOf('.');
         newPath = `${specPath.substring(0,pos) }_optimized.${ specPath.substring(pos+1)}`;
-
       } else {
         newPath = 'optimized-asyncapi.yaml';
       }

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -99,9 +99,12 @@ export default class Optimize extends Command {
 
       const specPath = specFile.getFilePath();
       let newPath = '';
+      let originalPath = '';
+
       if (specPath) {
         const pos = specPath.lastIndexOf('.');
         newPath = `${specPath.substring(0,pos) }_optimized.${ specPath.substring(pos+1)}`;
+
       } else {
         newPath = 'optimized-asyncapi.yaml';
       }
@@ -113,7 +116,8 @@ export default class Optimize extends Command {
         this.log(`Created file ${newPath}...`);
       } else if (this.outputMethod === Outputs.OVERWRITE) {
         await writeFile(specPath ?? 'asyncapi.yaml', optimizedDocument, { encoding: 'utf8' });
-        this.log(`Created file ${newPath}...`);
+
+        this.log(`Updated file ${specPath}...`);
       }
     } catch (error) {
       throw new ValidationError({


### PR DESCRIPTION
Correct the log command and name file after executing the optimise command,
<img width="439" alt="Screenshot 2023-09-19 at 1 14 14 PM" src="https://github.com/asyncapi/cli/assets/60972989/01d57d44-60ce-438e-8f82-6d9fcc3cfb12">


Related issue(s)
Fixes https://github.com/asyncapi/cli/issues/764