### PR TITLE
fix: update examples owned by CLI to v3

### DIFF
--- a/assets/examples/default-example.yaml
+++ b/assets/examples/default-example.yaml
@@ -1,13 +1,21 @@
-asyncapi: '2.2.0'
+asyncapi: 3.0.0
 info:
   title: Account Service
   version: 1.0.0
   description: This service is in charge of processing user signups
 channels:
-  user/signedup:
-    subscribe:
-      message:
+  userSignedUp:
+    address: user/signedup
+    messages:
+      UserSignedUp:
         $ref: '#/components/messages/UserSignedUp'
+operations:
+  onUserSignUp:
+    action: receive
+    channel:
+      $ref: '#/channels/userSignedUp'
+    messages:
+      - $ref: '#/channels/userSignedUp/messages/UserSignedUp'
 components:
   messages:
     UserSignedUp:

--- a/assets/examples/tutorial.yml
+++ b/assets/examples/tutorial.yml
@@ -1,24 +1,22 @@
-asyncapi: 2.5.0
+asyncapi: 3.0.0
 info:
-  title: Streetlights API Simplified
-  version: 1.0.0
+  title: Streetlights App
+  version: '1.0.0'
   description: |
-    The Smartylighting Streetlights API allows you to remotely manage the city lights.
-
-    This is a simplified version of the Streetlights API from other examples. This version is used in AsyncAPI documentation.
+    The Smartylighting Streetlights application allows you
+    to remotely manage the city lights.
   license:
     name: Apache 2.0
-    url: https://www.apache.org/licenses/LICENSE-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0'
 servers:
   mosquitto:
-    url: mqtt://test.mosquitto.org
+    host: test.mosquitto.org
     protocol: mqtt
 channels:
-  light/measured:
-    publish:
-      summary: Inform about environmental lighting conditions for a particular streetlight.
-      operationId: onLightMeasured
-      message:
+  lightMeasured:
+    address: 'light/measured'
+    messages:
+      lightMeasuredMessage:
         name: LightMeasured
         payload:
           type: object
@@ -35,3 +33,9 @@ channels:
               type: string
               format: date-time
               description: Date and time when the message was sent.
+operations:
+  onLightMeasured:
+    action: receive
+    summary: Information about environmental lighting conditions for a particular streetlight.
+    channel:
+      $ref: '#/channels/lightMeasured'


### PR DESCRIPTION
2 examples from CLI are owned by CLI, not fetched from `spec` repo - so updating them manually

the tutorial one is specifically important as used in https://v3.asyncapi.com/docs/tutorials/create-asyncapi-document