### PR TITLE
fix: update asyncapi document in default glee example

### DIFF
--- a/assets/create-glee-app/templates/default/asyncapi.yaml
+++ b/assets/create-glee-app/templates/default/asyncapi.yaml
@@ -20,13 +20,12 @@ operations:
     channel:
       $ref: '#/channels/hello'
     messages:
-      - $ref: '#/channels/hello/messages/onHelloMessage'
-  onHelloReply:
-    action: send
-    channel:
-      $ref: '#/channels/hello'
-    messages:
-      - $ref: '#/channels/hello/messages/subscribeMessage'
+      - $ref: '#/components/messages/hello'
+    reply:
+      channel:
+        $ref: '#/channels/hello'
+      messages:
+        - $ref: '#/components/messages/hello'
 components:
   messages:
     hello:

--- a/assets/create-glee-app/templates/default/asyncapi.yaml
+++ b/assets/create-glee-app/templates/default/asyncapi.yaml
@@ -12,8 +12,6 @@ channels:
     messages:
       onHelloMessage:
         $ref: '#/components/messages/hello'
-      subscribeMessage:
-        $ref: '#/components/messages/hello'
 operations:
   onHello:
     action: receive

--- a/assets/create-glee-app/templates/default/asyncapi.yaml
+++ b/assets/create-glee-app/templates/default/asyncapi.yaml
@@ -1,23 +1,32 @@
-asyncapi: 2.6.0
+asyncapi: 3.0.0
 info:
-  title: Hello, Glee!
+  title: 'Hello, Glee!'
   version: 0.1.0
-
 servers:
   websockets:
-    url: ws://0.0.0.0:3000
+    host: '0.0.0.0:3000'
     protocol: ws
-
 channels:
   hello:
-    publish:
-      operationId: onHello
-      message:
+    address: hello
+    messages:
+      onHelloMessage:
         $ref: '#/components/messages/hello'
-    subscribe:
-      message:
+      subscribeMessage:
         $ref: '#/components/messages/hello'
-
+operations:
+  onHello:
+    action: receive
+    channel:
+      $ref: '#/channels/hello'
+    messages:
+      - $ref: '#/channels/hello/messages/onHelloMessage'
+  onHelloReply:
+    action: send
+    channel:
+      $ref: '#/channels/hello'
+    messages:
+      - $ref: '#/channels/hello/messages/subscribeMessage'
 components:
   messages:
     hello:

--- a/assets/create-glee-app/templates/default/asyncapi.yaml
+++ b/assets/create-glee-app/templates/default/asyncapi.yaml
@@ -10,20 +10,16 @@ channels:
   hello:
     address: hello
     messages:
-      onHelloMessage:
+      hello:
         $ref: '#/components/messages/hello'
 operations:
   onHello:
     action: receive
     channel:
       $ref: '#/channels/hello'
-    messages:
-      - $ref: '#/components/messages/hello'
     reply:
       channel:
         $ref: '#/channels/hello'
-      messages:
-        - $ref: '#/components/messages/hello'
 components:
   messages:
     hello:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
`asyncapi new glee` command was creating a new glee project with `2.6.0` version of the spec. This PR is updating the `default` example to have spec `3.0.0` support. 

Fixes #829