### PR TITLE
fix: nullish examples in examples.json

### DIFF
--- a/scripts/fetch-asyncapi-example.js
+++ b/scripts/fetch-asyncapi-example.js
@@ -81,8 +81,7 @@ const buildCLIListFromExamples = async () => {
         value: example
       };
     } catch (error) {
-      // Failed for somereason to parse this spec file, ignore for now
-      return null;
+      console.error(error);
     }
   });
 

--- a/scripts/fetch-asyncapi-example.js
+++ b/scripts/fetch-asyncapi-example.js
@@ -86,7 +86,7 @@ const buildCLIListFromExamples = async () => {
     }
   });
 
-  const exampleList = await Promise.all(buildExampleList);
+  const exampleList = (await Promise.all(buildExampleList)).filter(item => item!==null);
   const orderedExampleList = exampleList.sort((a, b) => a.name.localeCompare(b.name));
 
   fs.writeFileSync(path.join(EXAMPLE_DIRECTORY, 'examples.json'), JSON.stringify(orderedExampleList, null, 4));

--- a/scripts/fetch-asyncapi-example.js
+++ b/scripts/fetch-asyncapi-example.js
@@ -86,7 +86,7 @@ const buildCLIListFromExamples = async () => {
     }
   });
 
-  const exampleList = (await Promise.all(buildExampleList)).filter(item => item !== null);
+  const exampleList = (await Promise.all(buildExampleList)).filter(item => !!item);
   const orderedExampleList = exampleList.sort((a, b) => a.name.localeCompare(b.name));
 
   fs.writeFileSync(path.join(EXAMPLE_DIRECTORY, 'examples.json'), JSON.stringify(orderedExampleList, null, 4));

--- a/scripts/fetch-asyncapi-example.js
+++ b/scripts/fetch-asyncapi-example.js
@@ -71,7 +71,7 @@ const buildCLIListFromExamples = async () => {
       const { document } = await parser.parse(exampleContent);
       // Failed for somereason to parse this spec file (document is undefined), ignore for now
       if (!document) {
-        return;
+        return null;
       }
 
       const title = document.info().title();
@@ -82,11 +82,11 @@ const buildCLIListFromExamples = async () => {
       };
     } catch (error) {
       // Failed for somereason to parse this spec file, ignore for now
-      console.error(error);
+      return null;
     }
   });
 
-  const exampleList = (await Promise.all(buildExampleList)).filter(item => item!==null);
+  const exampleList = (await Promise.all(buildExampleList)).filter(item => item !== null);
   const orderedExampleList = exampleList.sort((a, b) => a.name.localeCompare(b.name));
 
   fs.writeFileSync(path.join(EXAMPLE_DIRECTORY, 'examples.json'), JSON.stringify(orderedExampleList, null, 4));

--- a/scripts/fetch-asyncapi-example.js
+++ b/scripts/fetch-asyncapi-example.js
@@ -71,7 +71,7 @@ const buildCLIListFromExamples = async () => {
       const { document } = await parser.parse(exampleContent);
       // Failed for somereason to parse this spec file (document is undefined), ignore for now
       if (!document) {
-        return null;
+        return;
       }
 
       const title = document.info().title();


### PR DESCRIPTION
**Description**

- This PR addresses the issue related to the async-api CLI build process failing when encountering invalid examples in the spec repository. It filters out the null values from the exampleList.
- ...


**Related issue(s)**
Resolves #994