### PR TITLE
fix: exit with 1 for failing validations

### DIFF
--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -30,8 +30,8 @@ export default class Validate extends Command {
     }
 
     const validationResult = await validate(this, specFile, flags);
-    if (validationResult == 'invalid') {
-      this.exit(1);
+    if (validationResult === 'invalid') {
+      process.exitCode = 1;
     }
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -29,6 +29,9 @@ export default class Validate extends Command {
       specWatcher({ spec: specFile, handler: this, handlerName: 'validate' });
     }
 
-    await validate(this, specFile, flags);
+    const validationResult = await validate(this, specFile, flags);
+    if (validationResult == 'invalid') {
+      this.exit(1);
+    }
   }
 }

--- a/test/integration/validate.test.ts
+++ b/test/integration/validate.test.ts
@@ -239,9 +239,9 @@ describe('validate', () => {
       .stderr()
       .stdout()
       .command(['validate', './test/fixtures/specification.yml', '--fail-severity=warn'])
-      .exit(1)
       .it('works with --fail-severity', (ctx, done) => {
         expect(ctx.stderr).to.include('\nFile ./test/fixtures/specification.yml and/or referenced documents have governance issues.\n\ntest/fixtures/specification.yml');
+        expect(process.exitCode).to.equal(1);
         done();
       });
   });

--- a/test/integration/validate.test.ts
+++ b/test/integration/validate.test.ts
@@ -117,7 +117,7 @@ describe('validate', () => {
       testHelper.setCurrentContext('home');
       testHelper.deleteDummyContextFile();
     });
-    
+
     test
       .stderr()
       .stdout()
@@ -239,6 +239,7 @@ describe('validate', () => {
       .stderr()
       .stdout()
       .command(['validate', './test/fixtures/specification.yml', '--fail-severity=warn'])
+      .exit(1)
       .it('works with --fail-severity', (ctx, done) => {
         expect(ctx.stderr).to.include('\nFile ./test/fixtures/specification.yml and/or referenced documents have governance issues.\n\ntest/fixtures/specification.yml');
         done();


### PR DESCRIPTION
**Description**

Exit the `validate` with 1 for failing validations. Failing validations should exit with code 1 so they can be used in CI and also comply with the commands' documentation.

**Related issue(s)**
Resolves #861 
