### PR TITLE
chore: remove apostrophes from version in `release-chocolatey`

### DIFF
--- a/.github/workflows/release-chocolatey.yml
+++ b/.github/workflows/release-chocolatey.yml
@@ -28,6 +28,8 @@ jobs:
           else {
             $version = $(npm pkg get version)
           }
+
+          $version = $version.Replace("`"", "")
           echo "Setting version to $version"
           echo "version=$version" >> $env:GITHUB_OUTPUT
 


### PR DESCRIPTION
**Description**

- Removes apostrophes from the version in `release-chocolatey` as seen in #1069 

**Related issue(s)**
Fixes #1069 