### PR TITLE
feat: update studio command to use hosted instance

### DIFF
--- a/src/commands/new/file.ts
+++ b/src/commands/new/file.ts
@@ -2,7 +2,7 @@ import {Flags} from '@oclif/core';
 import { promises as fPromises, readFileSync } from 'fs';
 import Command from '../../base';
 import * as inquirer from 'inquirer';
-import { start as startStudio, DEFAULT_PORT } from '../../models/Studio';
+import { start as startStudio, DEFAULT_PORT, startOnline } from '../../models/Studio';
 import { resolve } from 'path';
 
 const { writeFile, readFile } = fPromises;
@@ -60,7 +60,8 @@ export default class NewFile extends Command {
 
     if (flags.studio) {
       if (isTTY) {
-        startStudio(fileName, flags.port || DEFAULT_PORT);
+        startOnline(fileName, flags.port || DEFAULT_PORT);
+        //startStudio(fileName, flags.port || DEFAULT_PORT);
       } else {
         this.warn('Warning: --studio flag was passed but the terminal is not interactive. Ignoring...');
       }
@@ -132,7 +133,7 @@ export default class NewFile extends Command {
     selectedTemplate = selectedTemplate || DEFAULT_ASYNCAPI_TEMPLATE;
 
     await this.createAsyncapiFile(fileName, selectedTemplate);
-    if (openStudio) { startStudio(fileName, flags.port || DEFAULT_PORT);}
+    if (openStudio) { startOnline(fileName, flags.port || DEFAULT_PORT);}
   }
 
   async createAsyncapiFile(fileName:string, selectedTemplate:string) {

--- a/src/commands/start/studio.ts
+++ b/src/commands/start/studio.ts
@@ -1,6 +1,6 @@
 import {Flags} from '@oclif/core';
 import Command from '../../base';
-import { start as startStudio } from '../../models/Studio';
+import { start as startStudio, startOnline } from '../../models/Studio';
 import { load } from '../../models/SpecificationFile';
 
 export default class StartStudio extends Command {
@@ -19,6 +19,7 @@ export default class StartStudio extends Command {
     const filePath = flags.file || (await load()).getFilePath();
     const port = flags.port;
 
-    startStudio(filePath as string, port);
+    //startStudio(filePath as string, port);
+    startOnline(filePath as string)
   }
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Currently, when CLI opens an `asyncapi` file in Studio it uses the older version of Studio so it does not support spec v3. To solve this we need to update to the latest version of Studio, but the npm package is not being updated and so this PR is trying an alternative to use the hosted studio to start and edit the spec file. 


#### Working 
CLI is creating a server and hosting the spec file with cors enabled opening the studio with URL as a parameter, for example `https://studio.asyncapi.com/?url=http://localhost:3210/fileread&url_save=http://localhost:3210/filesave` then open a websocket server for the studio to actually send back the changes made by the user to save locally to the spec file. 

