### PR TITLE
fix: duplicate methods in presets

### DIFF
--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -302,20 +302,8 @@ export default class Models extends Command {
         options
       });
       if (javaIncludeComments) {presets.push(JAVA_DESCRIPTION_PRESET);}
-      if (javaJackson) {
-        presets.push({
-          preset: JAVA_COMMON_PRESET,
-          options
-        },
-        JAVA_JACKSON_PRESET);
-      }
-      if (javaConstraints) {
-        presets.push({
-          preset: JAVA_COMMON_PRESET,
-          options
-        },
-        JAVA_CONSTRAINTS_PRESET);
-      }
+      if (javaJackson) {presets.push(JAVA_JACKSON_PRESET);}
+      if (javaConstraints) {presets.push(JAVA_CONSTRAINTS_PRESET);}
       fileGenerator = new JavaFileGenerator({ presets });
       fileOptions = {
         packageName


### PR DESCRIPTION
**Description**
`JAVA_COMMON_PRESET` was pushed twice to `presets` resulting in duplicate methods

**Related issue(s)**
fixes #1038