### PR TITLE
ci: skip trying to push an already pushed version

### DIFF
--- a/.github/workflows/release-chocolatey.yml
+++ b/.github/workflows/release-chocolatey.yml
@@ -33,7 +33,29 @@ jobs:
           echo "Setting version to $version"
           echo "version=$version" >> $env:GITHUB_OUTPUT
 
+      - name: Check if this is a new version to release
+        id: check_new_version
+        run: |
+          $output = choco search asyncapi-cli --version=${{ steps.release_version.outputs.version }}
+          # Output is of the form:
+          # Chocolatey v2.2.2
+          # asyncapi-cli 0.0.1 [Approved]
+          # 1 packages found.
+          # If the version is not found, the output will of the form:
+          # Chocolatey v2.2.2
+          # 0 packages found.
+
+          if ($output -match "0 packages found.") {
+            echo "This is a new version to release"
+            echo "new_version=true" >> $env:GITHUB_OUTPUT
+          }
+          else {
+            echo "This is not a new version to release"
+            echo "new_version=false" >> $env:GITHUB_OUTPUT
+          }
+          
       - name: Download release
+        if: steps.check_new_version.outputs.new_version == 'true'
         run: |
           echo "Downloading release assets for version ${{ steps.release_version.outputs.version }}"
           mkdir -p ./dist/win32
@@ -41,6 +63,7 @@ jobs:
           curl -L "https://github.com/asyncapi/cli/releases/download/v${{ steps.release_version.outputs.version }}/asyncapi.x86.exe" -o "./dist/win32/asyncapi.x86.exe"
 
       - name: Get Checksum of the release
+        if: steps.check_new_version.outputs.new_version == 'true'
         id: release_checksum
         run: |
           $checksum = (Get-FileHash -Path "./dist/win32/asyncapi.x86.exe" -Algorithm SHA256).Hash
@@ -51,11 +74,13 @@ jobs:
           echo "checksum64=$checksum64" >> $env:GITHUB_OUTPUT
 
       - name: Make nuspec from the template
+        if: steps.check_new_version.outputs.new_version == 'true'
         run: |
           cd ./.github/workflows/deploy/chocolatey
           pwsh -File ./replace.ps1 -version ${{ steps.release_version.outputs.version }} -checksum ${{ steps.release_checksum.outputs.checksum }} -checksum64 ${{ steps.release_checksum.outputs.checksum64 }}
 
       - name: Run Chocolatey Pack
+        if: steps.check_new_version.outputs.new_version == 'true'
         run: |
           cd ./.github/workflows/deploy/chocolatey
           choco pack ./asyncapi-cli.nuspec


### PR DESCRIPTION
**Description**

Check if the version to be pushed has already been pushed to the remote.

**Related issue(s)**
https://asyncapi.slack.com/archives/CQVJXFNQL/p1710432214064749?thread_ts=1710238071.506779&cid=CQVJXFNQL

**Examples**
- [If a package is not pushed it will build normally](https://github.com/ash17290/cli/actions/runs/8287047957/job/22678466474)
- [Else will skip everything](https://github.com/ash17290/cli/actions/runs/8287051904/job/22678478986)
