### PR TITLE
fix: trigger release of assets with fixed assets workflow

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -49,8 +49,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "${{ steps.lockversion.outputs.version }}"
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
       - name: Get version from package.json
         uses: actions/github-script@v6
         id: extractver
@@ -59,8 +57,13 @@ jobs:
             const packageJson = require('./package.json');
             const packageJsonVersion = packageJson.version;
             core.setOutput('version', packageJsonVersion);
+      - if: steps.lockversion.outputs.version == '18' && matrix.os == 'windows-latest'
+        #npm cli 10 is buggy because of some cache issue
+        name: Install npm cli 8
+        shell: bash
+        run: npm install -g npm@8.19.4
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build project
         run: npm run prepublishOnly
       - name: Assets generation


### PR DESCRIPTION
applying the same fixes as in https://github.com/asyncapi/cli/pull/1340 

I forgot that we have one more workflow that uses windows