### PR TITLE
refactor: add enum for spec file's validation status

### DIFF
--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core';
 import Command from '../base';
-import { validate, validationFlags } from '../parser';
+import { validate, validationFlags, ValidationStatus } from '../parser';
 import { load } from '../models/SpecificationFile';
 import { specWatcher } from '../globals';
 import { watchFlag } from '../flags';
@@ -31,7 +31,7 @@ export default class Validate extends Command {
     const result = await validate(this, this.specFile, flags);
     this.metricsMetadata.validation_result = result;
     
-    if (result === 'invalid') {
+    if (result === ValidationStatus.INVALID) {
       process.exitCode = 1;
     }
   }


### PR DESCRIPTION
This PR will refactor the spec file's validation status returned by `parser.ts`.

**Related issue(s):**
Relates to https://github.com/asyncapi/cli/pull/877