### PR TITLE
fix: enable to use nodejs and java templates with asyncapi v3

### DIFF
--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -36,8 +36,6 @@ const templatesNotSupportingV3: Record<string, string> = {
   '@asyncapi/java-spring-cloud-stream-template': 'https://github.com/asyncapi/java-spring-cloud-stream-template/issues/336',
   '@asyncapi/go-watermill-template': 'https://github.com/asyncapi/go-watermill-template/issues/243',
   '@asyncapi/java-spring-template': 'https://github.com/asyncapi/java-spring-template/issues/308',
-  '@asyncapi/nodejs-template': 'https://github.com/asyncapi/nodejs-template/issues/215',
-  '@asyncapi/java-template': 'https://github.com/asyncapi/java-template/issues/118',
   '@asyncapi/php-template': 'https://github.com/asyncapi/php-template/issues/191'
 };
 


### PR DESCRIPTION
with current code we get https://github.com/asyncapi/nodejs-template/issues/215#issuecomment-2098550341 error

nodejs template already supports v3: https://github.com/asyncapi/nodejs-template/releases/tag/v3.0.0
joava template as well: https://github.com/asyncapi/java-template/releases/tag/v0.3.0