### PR TITLE
test: handle a different analytics config file for testing

### DIFF
--- a/test/integration/config/analytics.test.ts
+++ b/test/integration/config/analytics.test.ts
@@ -5,7 +5,7 @@ describe('config:analytics', () => {
     test
       .stderr()
       .stdout()
-      .command(['config:analytics', '--disable'])
+      .command(['ASYNCAPI_METRICS_CONFIG_PATH=./test/fixtures/.asyncapi-analytics', 'config:analytics', '--disable'])
       .it('should show a successful message once the analytics are disabled', async (ctx, done) => {
         expect(ctx.stdout).to.equal('\nAnalytics disabled.\n\n');
         expect(ctx.stderr).to.equal('');
@@ -17,7 +17,7 @@ describe('config:analytics', () => {
     test
       .stderr()
       .stdout()
-      .command(['config:analytics', '--enable'])
+      .command(['ASYNCAPI_METRICS_CONFIG_PATH=./test/fixtures/.asyncapi-analytics', 'config:analytics', '--enable'])
       .it('should show a successful message once the analytics are enabled', (ctx, done) => {
         expect(ctx.stdout).to.equal('\nAnalytics enabled.\n\n');
         expect(ctx.stderr).to.equal('');
@@ -29,7 +29,7 @@ describe('config:analytics', () => {
     test
       .stderr()
       .stdout()
-      .command(['config:analytics'])
+      .command(['ASYNCAPI_METRICS_CONFIG_PATH=./test/fixtures/.asyncapi-analytics', 'config:analytics'])
       .it('should show informational message when no flags are used', (ctx, done) => {
         expect(ctx.stdout).to.equal('\nPlease append the "--disable" flag to the command in case you prefer to disable analytics, or use the "--enable" flag if you want to enable analytics back again. In case you do not know the analytics current status, then you can append the "--status" flag to be aware of it.\n\n');
         expect(ctx.stderr).to.equal('');
@@ -41,7 +41,7 @@ describe('config:analytics', () => {
     test
       .stderr()
       .stdout()
-      .command(['config:analytics', '--status'])
+      .command(['ASYNCAPI_METRICS_CONFIG_PATH=./test/fixtures/.asyncapi-analytics', 'config:analytics', '--status'])
       .it('should show a different informational message depending on the analytics status', (ctx, done) => {
         expect(ctx.stdout).to.contain('\nAnalytics are ');
         expect(ctx.stderr).to.equal('');

--- a/test/integration/config/analytics.test.ts
+++ b/test/integration/config/analytics.test.ts
@@ -1,11 +1,22 @@
 import { expect, test } from '@oclif/test';
+import { fileCleanup } from '../../helpers';
+
+const analyticsConfigFilePath = './test/fixtures/.asyncapi-analytics';
 
 describe('config:analytics', () => {
+  beforeEach(() => {
+    process.env = Object.assign(process.env, { ASYNCAPI_METRICS_CONFIG_PATH: analyticsConfigFilePath });
+  });
+
+  afterEach(() => {
+    fileCleanup(analyticsConfigFilePath);
+  });
+
   describe('with disable flag', () => {
     test
       .stderr()
       .stdout()
-      .command(['ASYNCAPI_METRICS_CONFIG_PATH=./test/fixtures/.asyncapi-analytics', 'config:analytics', '--disable'])
+      .command(['config:analytics', '--disable'])
       .it('should show a successful message once the analytics are disabled', async (ctx, done) => {
         expect(ctx.stdout).to.equal('\nAnalytics disabled.\n\n');
         expect(ctx.stderr).to.equal('');
@@ -17,7 +28,7 @@ describe('config:analytics', () => {
     test
       .stderr()
       .stdout()
-      .command(['ASYNCAPI_METRICS_CONFIG_PATH=./test/fixtures/.asyncapi-analytics', 'config:analytics', '--enable'])
+      .command(['config:analytics', '--enable'])
       .it('should show a successful message once the analytics are enabled', (ctx, done) => {
         expect(ctx.stdout).to.equal('\nAnalytics enabled.\n\n');
         expect(ctx.stderr).to.equal('');
@@ -29,7 +40,7 @@ describe('config:analytics', () => {
     test
       .stderr()
       .stdout()
-      .command(['ASYNCAPI_METRICS_CONFIG_PATH=./test/fixtures/.asyncapi-analytics', 'config:analytics'])
+      .command(['config:analytics'])
       .it('should show informational message when no flags are used', (ctx, done) => {
         expect(ctx.stdout).to.equal('\nPlease append the "--disable" flag to the command in case you prefer to disable analytics, or use the "--enable" flag if you want to enable analytics back again. In case you do not know the analytics current status, then you can append the "--status" flag to be aware of it.\n\n');
         expect(ctx.stderr).to.equal('');
@@ -41,7 +52,7 @@ describe('config:analytics', () => {
     test
       .stderr()
       .stdout()
-      .command(['ASYNCAPI_METRICS_CONFIG_PATH=./test/fixtures/.asyncapi-analytics', 'config:analytics', '--status'])
+      .command(['config:analytics', '--status'])
       .it('should show a different informational message depending on the analytics status', (ctx, done) => {
         expect(ctx.stdout).to.contain('\nAnalytics are ');
         expect(ctx.stderr).to.equal('');


### PR DESCRIPTION
This PR will allow to set up the env var `ASYNCAPI_METRICS_CONFIG_PATH` to a known and controlled config file path instead of using the one located in ~home.

Relates to #1427 