### PR TITLE
fix: modelina supporting asyncapi v3

### DIFF
--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -30,9 +30,7 @@ export default class Models extends Command {
     }
 
     const inputFile = (await load(file)) || (await load());
-    if (inputFile.isAsyncAPI3()) {
-      this.error('Generate Models command does not support AsyncAPI v3 yet, please checkout https://github.com/asyncapi/modelina/issues/1376');
-    }
+
     const { document, diagnostics ,status } = await parse(this, inputFile, flags);
     if (!document || status === 'invalid') {
       const severityErrors = diagnostics.filter((obj) => obj.severity === 0);

--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -32,6 +32,7 @@ export default class Models extends Command {
     const inputFile = (await load(file)) || (await load());
 
     const { document, diagnostics ,status } = await parse(this, inputFile, flags);
+
     if (!document || status === 'invalid') {
       const severityErrors = diagnostics.filter((obj) => obj.severity === 0);
       this.log(`Input is not a correct AsyncAPI document so it cannot be processed.${formatOutput(severityErrors,'stylish','error')}`);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Removing the check for spec v3 as now modelina support AsyncAPI spec v3.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

See also https://github.com/asyncapi/cli/pull/1376