### PR TITLE
fix: windows asset release

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -50,6 +50,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.lockversion.outputs.version }}"
+      - if: matrix.npm_script == 'pack:windows'
+        name: install nodejs for windows
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Get version from package.json
         uses: actions/github-script@v6
         id: extractver


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Oclif v4 needs nodejs v20+ to generate assets. This PR is updating the release workflow to install nodejs 20 for windows. 

![image](https://github.com/user-attachments/assets/feacb884-2bfc-497a-a23e-6efe1e9f2bdc)


