### PR TITLE
feat: implemented logic to output diagnostics log by adding additional output flag to validate cli command.

### DIFF
--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -99,42 +99,6 @@ export async function parse(command: Command, specFile: Specification, options: 
   return { document, diagnostics, status };
 }
 
-// function logDiagnostics(diagnostics: Diagnostic[], command: Command, specFile: Specification, options: ValidateOptions = {}): 'valid' | 'invalid' {
-//   const logDiagnostics = options['log-diagnostics'];
-//   const failSeverity = options['fail-severity'] ?? 'error';
-//   const diagnosticsFormat = options['diagnostics-format'] ?? 'stylish';
-
-//   const sourceString = specFile.toSourceString();
-//   if (diagnostics.length) {
-//     if (hasFailSeverity(diagnostics, failSeverity)) {
-//       if (logDiagnostics) {
-//         command.logToStderr(`\n${sourceString} and/or referenced documents have governance issues.`);
-//         const diagnosticsOutput = formatOutput(diagnostics, diagnosticsFormat, failSeverity);
-//         if (options.output) {
-//           writeValidationDiagnostic(options.output, command, diagnosticsFormat, diagnosticsOutput);
-//         } else {
-//           command.log(diagnosticsOutput);
-//         }
-//       }
-//       return ValidationStatus.INVALID;
-//     }
-
-//     if (logDiagnostics) {
-//       command.log(`\n${sourceString} is valid but has (itself and/or referenced documents) governance issues.`);
-//       const diagnosticsOutput = formatOutput(diagnostics, diagnosticsFormat, failSeverity);
-//       if (options.output) {
-//         writeValidationDiagnostic(options.output, command, diagnosticsFormat, diagnosticsOutput);
-//       } else {
-//         command.log(diagnosticsOutput);
-//       }
-//     }
-//   } else if (logDiagnostics) {
-//     command.log(`\n${sourceString} is valid! ${sourceString} and referenced documents don't have governance issues.`);
-//   }
-
-//   return ValidationStatus.VALID;
-// }
-
 function logDiagnostics(
   diagnostics: Diagnostic[],
   command: Command,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Added additional output flag param ```-o``` to output diagnostics log to a file.
- By default the diagnostics log will be printed in terminal.

**Related issue(s)**
Resolves #1095 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->