### PR TITLE
feat: #1564

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,7 @@
     "sonarjs/no-small-switch": "off",
     "security/detect-non-literal-fs-filename": "off",
     "no-process-exit": "error",
-    "no-warning-comments": "error",
+    "no-warning-comments": "off",
     "no-loop-func": "error",
     "curly": ["error"],
     "no-multi-spaces": "error",
@@ -34,12 +34,12 @@
     "func-style": 0,
     "max-nested-callbacks": ["error", 3],
     "camelcase": 0,
-    "no-debugger": 1,
-    "no-empty": 1,
-    "no-invalid-regexp": 1,
-    "no-unused-expressions": 1,
+    "no-debugger": 0,
+    "no-empty": 0,
+    "no-invalid-regexp": 2,
+    "no-unused-expressions": 0,
     "no-native-reassign": 1,
-    "no-fallthrough": 1,
+    "no-fallthrough": 2,
     "sonarjs/cognitive-complexity": 1,
     "eqeqeq": 2,
     "no-undef": "off",
@@ -102,7 +102,7 @@
       "last"
     ],
     "no-multiple-empty-lines": [
-      2,
+      0,
       {
         "max": 1
       }
@@ -113,7 +113,7 @@
       "always"
     ],
     "padded-blocks": [
-      2,
+      0,
       "never"
     ],
     "quote-props": [


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

For feat: #1564 

**Description**

- Adjusted ESLint configurations for CI/CD processes to suppress non-critical warnings and streamline development.
- Improved rule consistency and selectively disabled non-essential rules for cleaner CI/CD logs.

**Key Adjustments**

### Suppress Irrelevant Warnings
- **"no-warning-comments": "off"**  
  *Current:* `"no-warning-comments": "error"`  
  *Change:* Set to `"off"` to prevent `TODO`, `FIXME`, and other notes from triggering CI/CD errors.  
  *Reason:* These comments are typically reminders and are not critical for CI/CD.

- **"no-debugger": 0** and **"no-console": "off"**  
  *Current:* `"no-debugger": 1`  
  *Change:* Set `"no-debugger"` to `0` and `"no-console": "off"` to avoid flagging debugging and console statements.  
  *Reason:* Debug and console statements may be intentional for development and usually harmless in non-production branches.

### Enable Soft Warnings Instead of Errors
- **"no-empty": 0**  
  *Current:* `"no-empty": 1`  
  *Change:* Set `"no-empty"` to `0` to allow empty blocks where intentional.  
  *Reason:* Empty blocks can occur during early development or debugging stages.

- **"no-unused-expressions": 0**  
  *Current:* `"no-unused-expressions": 1`  
  *Change:* Set to `0` if unused expressions are placeholders or not crucial.  
  *Reason:* Reduces noise from expressions commonly used in development.

### Enable Consistent Warning Levels
- **"no-invalid-regexp": 2**  
  *Current:* `"no-invalid-regexp": 1`  
  *Change:* Set to `2` for strict checking of regular expressions.  
  *Reason:* Ensures invalid regexes, which can cause crashes, are consistently flagged as errors.

- **"no-fallthrough": 2**  
  *Current:* `"no-fallthrough": 1`  
  *Change:* Set to `2` to ensure proper documentation of intentional fall-through in switch statements.  
  *Reason:* Helps avoid unintended behavior, essential for a stable CLI.

### Disable Non-Essential Rules Temporarily
- **"no-multiple-empty-lines": 0** and **"padded-blocks": 0**  
  *Current:* Set to enforce spacing and padding.  
  *Change:* Set to `0` to ignore multiple empty lines and padded blocks.  
  *Reason:* These are stylistic and not essential for functionality-focused CI/CD checks.
>

---

Doc I referred : https://typescript-eslint.io/rules/

---

PS: I am new in understanding this code repo and workflow there are high chances of wrong understanding from my end, but I will improve as per the requirement.