### PR TITLE
fix: prepare action for release

### DIFF
--- a/.changeset/prep-action.md
+++ b/.changeset/prep-action.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Prepare github action for release

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Generator, Validator, Converter and others - all in one for your AsyncAPI docs'
-description: 'Use this action to generate docs or code from your AsyncAPI document. Use default templates or provide your custom ones.'
+name: 'AsyncAPI CLI Action'
+description: 'One stop solution for all your AsyncAPI Specification needs in github actions. Use this action to generate code, validate your AsyncAPI document, convert it to other formats, optimize it or run custom commands.'
 inputs:
   cli_version:
     description: 'Version of AsyncAPI CLI to be used. This is only needed if you want to test with a specific version of AsyncAPI CLI. Default is latest which is also the recommended option.'


### PR DESCRIPTION
Changing name of the action as apparently name should be unique.

![image](https://github.com/user-attachments/assets/88602a9b-f0eb-48b2-b002-3697f6ca2d23)
