### PR TITLE
fix: resolved faulty spinner loading after error in console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/cli",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/cli",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.23",

--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -71,7 +71,7 @@ export default class Models extends Command {
       });
       s.stop(green(`Successfully generated the following models: ${generatedModelStrings.join('\n')}`));
     } catch (error) {
-      s.stop(green("Failed to generate models")); 
+      s.stop(green('Failed to generate models')); 
 
       if (error instanceof Error) {
         this.error(error.message);

--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -56,19 +56,29 @@ export default class Models extends Command {
 
     const s = spinner();
     s.start('Generating models...');
-    const generatedModels = await generateModels({...flags, output}, document, logger, language as Languages);
-    if (output !== 'stdout') {
-      const generatedModelStrings = generatedModels.map((model) => { return model.modelName; });
-      s.stop(green(`Successfully generated the following models: ${generatedModelStrings.join(', ')}`));
-      return;
-    }
-    const generatedModelStrings = generatedModels.map((model) => {
-      return `
-## Model name: ${model.modelName}
-${model.result}
-      `;
-    });
-    s.stop(green(`Successfully generated the following models: ${generatedModelStrings.join('\n')}`));
+    try {
+      const generatedModels = await generateModels({...flags, output}, document, logger, language as Languages);
+      if (output !== 'stdout') {
+        const generatedModelStrings = generatedModels.map((model) => { return model.modelName; });
+        s.stop(green(`Successfully generated the following models: ${generatedModelStrings.join(', ')}`));
+        return;
+      }
+      const generatedModelStrings = generatedModels.map((model) => {
+        return `
+  ## Model name: ${model.modelName}
+  ${model.result}
+        `;
+      });
+      s.stop(green(`Successfully generated the following models: ${generatedModelStrings.join('\n')}`));
+    } catch (error) {
+      s.stop(green("Failed to generate models")); 
+
+      if (error instanceof Error) {
+        this.error(error.message);
+      } else {
+        this.error('An unknown error occurred during model generation.');
+      }
+    }    
   }
 
   private async parseArgs(args: Record<string, any>, output?: string) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Added a try catch to stop spinner if `Error` is throw by `generateModels()` func.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

Resolves #1607 