### PR TITLE
feat: make asyncapi start studio consistent with other commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/cli",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/cli",
-      "version": "2.14.1",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.23",
@@ -427,8 +427,11 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@asyncapi/minimaltemplate": {
-      "resolved": "test/fixtures/minimaltemplate",
-      "link": true
+      "resolved": "file:test/fixtures/minimaltemplate",
+      "dev": true,
+      "dependencies": {
+        "@asyncapi/generator-react-sdk": "^1.1.2"
+      }
     },
     "node_modules/@asyncapi/modelina": {
       "version": "4.0.0-next.62",
@@ -647,8 +650,11 @@
       }
     },
     "node_modules/@asyncapi/newtemplate": {
-      "resolved": "test/fixtures/newtemplate",
-      "link": true
+      "resolved": "file:test/fixtures/newtemplate",
+      "dev": true,
+      "dependencies": {
+        "@asyncapi/generator-react-sdk": "^1.1.1"
+      }
     },
     "node_modules/@asyncapi/nunjucks-filters": {
       "version": "2.1.0",
@@ -24912,18 +24918,6 @@
         "react": {
           "optional": true
         }
-      }
-    },
-    "test/fixtures/minimaltemplate": {
-      "dev": true,
-      "dependencies": {
-        "@asyncapi/generator-react-sdk": "^1.1.2"
-      }
-    },
-    "test/fixtures/newtemplate": {
-      "dev": true,
-      "dependencies": {
-        "@asyncapi/generator-react-sdk": "^1.1.1"
       }
     }
   }

--- a/src/commands/start/studio.ts
+++ b/src/commands/start/studio.ts
@@ -2,18 +2,36 @@ import Command from '../../core/base';
 import { start as startStudio } from '../../core/models/Studio';
 import { load } from '../../core/models/SpecificationFile';
 import { studioFlags } from '../../core/flags/start/studio.flags';
+import { Args } from '@oclif/core';
+import { ValidationError } from '../../core/errors/validation-error';
 
 export default class StartStudio extends Command {
   static description = 'starts a new local instance of Studio';
 
   static flags = studioFlags();
 
+  static readonly args = {
+    'spec-file': Args.string({
+      description: 'spec path, url, or context-name',
+      required: true,
+    }),
+  };
+
   async run() {
-    const { flags } = await this.parse(StartStudio);
-    const filePath = flags.file || (await load()).getFilePath();
+    const { args, flags } = await this.parse(StartStudio);
+    const filePath = args['spec-file'];
     const port = flags.port;
-    
-    this.specFile = await load(filePath);
+
+    try {
+      this.specFile = await load(filePath);
+    } catch (err) {
+      this.error(
+        new ValidationError({
+          type: 'invalid-file',
+          filepath: filePath,
+        }),
+      );
+    }
     this.metricsMetadata.port = port;
 
     startStudio(filePath as string, port);

--- a/src/core/flags/start/studio.flags.ts
+++ b/src/core/flags/start/studio.flags.ts
@@ -3,7 +3,6 @@ import { Flags } from '@oclif/core';
 export const studioFlags = () => {
   return {
     help: Flags.help({ char: 'h' }),
-    file: Flags.string({ char: 'f', description: 'path to the AsyncAPI file to link with Studio' }),
     port: Flags.integer({ char: 'p', description: 'port in which to start Studio' }),
   };
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Solves Issue : #1623
- Removed the flag -f, now user can directly input the filename from cli without using -f
- Hints are presented in the cli when --help is used
