### PR TITLE
feat: make asyncapi start studio consistent

### DIFF
--- a/src/commands/start/studio.ts
+++ b/src/commands/start/studio.ts
@@ -2,18 +2,36 @@ import Command from '../../core/base';
 import { start as startStudio } from '../../core/models/Studio';
 import { load } from '../../core/models/SpecificationFile';
 import { studioFlags } from '../../core/flags/start/studio.flags';
+import { Args } from '@oclif/core';
+import { ValidationError } from '../../core/errors/validation-error';
 
 export default class StartStudio extends Command {
   static description = 'starts a new local instance of Studio';
 
   static flags = studioFlags();
 
+  static readonly args = {
+    'spec-file': Args.string({
+      description: 'spec path, url, or context-name',
+      required: true,
+    }),
+  };
+
   async run() {
-    const { flags } = await this.parse(StartStudio);
-    const filePath = flags.file || (await load()).getFilePath();
+    const { args, flags } = await this.parse(StartStudio);
+    const filePath = args['spec-file'];
     const port = flags.port;
-    
-    this.specFile = await load(filePath);
+
+    try {
+      this.specFile = await load(filePath);
+    } catch (err) {
+      this.error(
+        new ValidationError({
+          type: 'invalid-file',
+          filepath: filePath,
+        }),
+      );
+    }
     this.metricsMetadata.port = port;
 
     startStudio(filePath as string, port);

--- a/src/core/flags/start/studio.flags.ts
+++ b/src/core/flags/start/studio.flags.ts
@@ -3,7 +3,6 @@ import { Flags } from '@oclif/core';
 export const studioFlags = () => {
   return {
     help: Flags.help({ char: 'h' }),
-    file: Flags.string({ char: 'f', description: 'path to the AsyncAPI file to link with Studio' }),
     port: Flags.integer({ char: 'p', description: 'port in which to start Studio' }),
   };
 };


### PR DESCRIPTION
Description
Solves Issue : #1623 
Removed the flag -f, now user can directly input the filename from cli without using -f
Hints are presented in the cli when --help is used