### PR TITLE
fix: remove an error at the end of the -h "help" flag

### DIFF
--- a/src/core/base.ts
+++ b/src/core/base.ts
@@ -32,6 +32,10 @@ export default abstract class extends Command {
     try {
       return await super.catch(err);
     } catch (e: any) {
+      if (e.message.includes('EEXIT: 0')) {
+        process.exitCode = 0;
+        return;
+      }
       if (e instanceof Error) {
         this.logToStderr(`${e.name}: ${e.message}`);
         process.exitCode = 1;


### PR DESCRIPTION
**Related issue(s)**
Resolves  #1625 

**Description**
This PR helps to fix the ERROR message issue in the -h help command flag.

### Approach
Upon going through the  codebase i first tried to log more of error message and got the following for stack trace of the error message.
![15_01_2025_WindowsTerminal_25_54](https://github.com/user-attachments/assets/58611ce1-630d-46ce-ade1-c8962dace350)

With referring to above trace and going through the oclif codebase i found that the error being shown here is not an actual error but just used to terminate the help command.
[This is that particular code.](https://github.com/oclif/core/blob/64e680d969b1c316459cb7fae50e70309435686b/src/flags.ts#L176)

Then after carefully going through help command implementation in the oclif codebase and also referring to an already mentioned [old issue](https://github.com/forcedotcom/cli/issues/589) about this bug and their [solution](https://github.com/oclif/errors/pull/157) i concluded that this error is safe to ignore as this is expected in the command output and is not critical.

@AayushSaini101 Please review this PR. 
Thanks.
