### PR TITLE
fix: made studio command consistent with other commands

### DIFF
--- a/asyncapi.yml
+++ b/asyncapi.yml
@@ -1,0 +1,9 @@
+asyncapi: '3.0.0'
+info:
+  title: Welcome to AsyncAPI Studio
+  version: '1.0.0'
+  description: This is a sample AsyncAPI document to help you get started. Define your async APIs, channels, messages, and bindings here.
+  contact:
+    name: AsyncAPI 
+    url: https://www.asyncapi.com
+    email: support@asyncapi.org

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -786,10 +786,12 @@ starts a new local instance of Studio
 
 ```
 USAGE
-  $ asyncapi start studio [-h] [-f <value>] [-p <value>]
+  $ asyncapi start studio [SPEC_FILE] [-h] [-p <value>]
+
+ARGUMENTS
+  SPEC-FILE  spec path, url, or context-name
 
 FLAGS
-  -f, --file=<value>  path to the AsyncAPI file to link with Studio
   -h, --help          Show CLI help.
   -p, --port=<value>  port in which to start Studio
 

--- a/src/commands/start/studio.ts
+++ b/src/commands/start/studio.ts
@@ -2,16 +2,25 @@ import Command from '../../core/base';
 import { start as startStudio } from '../../core/models/Studio';
 import { load } from '../../core/models/SpecificationFile';
 import { studioFlags } from '../../core/flags/start/studio.flags';
+import { Args } from '@oclif/core';
 
 export default class StartStudio extends Command {
   static description = 'starts a new local instance of Studio';
 
   static flags = studioFlags();
 
+  static readonly args = {
+    'spec-file': Args.string({description: 'spec path, url, or context-name', required: false}),
+  };
+
   async run() {
-    const { flags } = await this.parse(StartStudio);
-    const filePath = flags.file || (await load()).getFilePath();
+    const { args, flags } = await this.parse(StartStudio);
+    const filePath = args['spec-file'] || (await load()).getFilePath();
     const port = flags.port;
+
+    if (!args['spec-file']) {
+      this.log('\nTo open a specific AsyncAPI file in the Studio, use: asyncapi start studio [your-spec-file-location]\n\n');
+    }
     
     this.specFile = await load(filePath);
     this.metricsMetadata.port = port;

--- a/src/core/flags/start/studio.flags.ts
+++ b/src/core/flags/start/studio.flags.ts
@@ -3,7 +3,6 @@ import { Flags } from '@oclif/core';
 export const studioFlags = () => {
   return {
     help: Flags.help({ char: 'h' }),
-    file: Flags.string({ char: 'f', description: 'path to the AsyncAPI file to link with Studio' }),
     port: Flags.integer({ char: 'p', description: 'port in which to start Studio' }),
   };
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Updated `asyncapi start studio` command to input spec file as a argument rather than from a  `-f` flag.
- Added instruction in console on how to open studio with own spec file . This instruction is only visible when no spec file arg is specified .
- Updated docs to reflect the change in `asyncapi start studio` command usage.
- Added a default `asyncapi.yml` file to open in case no spec file is passed as input argument.


### **Screenshots**

- Default spec file `asyncapi.yml` opens when not specified with `start studio` command with terminal instruction on how to open own spec file .

![Screenshot from 2025-01-18 18-09-54](https://github.com/user-attachments/assets/4788c5e3-9432-4199-9d7a-5c78f456538f)

Output :
```bash
To open a specific AsyncAPI file in the Studio, use: asyncapi start studio [your-spec-file-location]

Studio is now running at http://localhost:3210?liveServer=3210&studio-version=0.20.2.
You can open this URL in your web browser, and if needed, press Ctrl + C to stop the process.
Watching changes on file asyncapi.yml
```

![Screenshot from 2025-01-18 18-09-25](https://github.com/user-attachments/assets/1d3e39aa-f6a8-4371-baad-dad7a0afdf58)

- Instruction is not logged when using own spec file .

![Screenshot from 2025-01-18 18-10-32](https://github.com/user-attachments/assets/ba8730a8-42aa-4dea-a0bc-56b421b9d7dc)

Output :
```bash
Studio is now running at http://localhost:3210?liveServer=3210&studio-version=0.20.2.
You can open this URL in your web browser, and if needed, press Ctrl + C to stop the process.
Watching changes on file /home/sahil/test.yaml
```


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

Resolves #1623 