### PR TITLE
feat: remove -f flag from asyncapi start command

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,33 +38,35 @@ USAGE
 # Commands
 
 <!-- commands -->
-* [`asyncapi bundle`](#asyncapi-bundle)
-* [`asyncapi config`](#asyncapi-config)
-* [`asyncapi config analytics`](#asyncapi-config-analytics)
-* [`asyncapi config context`](#asyncapi-config-context)
-* [`asyncapi config context add CONTEXT-NAME SPEC-FILE-PATH`](#asyncapi-config-context-add-context-name-spec-file-path)
-* [`asyncapi config context current`](#asyncapi-config-context-current)
-* [`asyncapi config context edit CONTEXT-NAME NEW-SPEC-FILE-PATH`](#asyncapi-config-context-edit-context-name-new-spec-file-path)
-* [`asyncapi config context init [CONTEXT-FILE-PATH]`](#asyncapi-config-context-init-context-file-path)
-* [`asyncapi config context list`](#asyncapi-config-context-list)
-* [`asyncapi config context remove CONTEXT-NAME`](#asyncapi-config-context-remove-context-name)
-* [`asyncapi config context use CONTEXT-NAME`](#asyncapi-config-context-use-context-name)
-* [`asyncapi config versions`](#asyncapi-config-versions)
-* [`asyncapi convert [SPEC-FILE] [PROXYHOST] [PROXYPORT]`](#asyncapi-convert-spec-file-proxyhost-proxyport)
-* [`asyncapi diff OLD NEW`](#asyncapi-diff-old-new)
-* [`asyncapi format [SPEC-FILE]`](#asyncapi-format-spec-file)
-* [`asyncapi generate`](#asyncapi-generate)
-* [`asyncapi generate fromTemplate ASYNCAPI TEMPLATE`](#asyncapi-generate-fromtemplate-asyncapi-template)
-* [`asyncapi generate models LANGUAGE FILE`](#asyncapi-generate-models-language-file)
-* [`asyncapi new`](#asyncapi-new)
-* [`asyncapi new file`](#asyncapi-new-file)
-* [`asyncapi new glee`](#asyncapi-new-glee)
-* [`asyncapi new template`](#asyncapi-new-template)
-* [`asyncapi optimize [SPEC-FILE] [PROXYHOST] [PROXYPORT]`](#asyncapi-optimize-spec-file-proxyhost-proxyport)
-* [`asyncapi pretty SPEC-FILE`](#asyncapi-pretty-spec-file)
-* [`asyncapi start`](#asyncapi-start)
-* [`asyncapi start studio`](#asyncapi-start-studio)
-* [`asyncapi validate [SPEC-FILE] [PROXYHOST] [PROXYPORT]`](#asyncapi-validate-spec-file-proxyhost-proxyport)
+- [Usage](#usage)
+- [Commands](#commands)
+  - [`asyncapi bundle`](#asyncapi-bundle)
+  - [`asyncapi config`](#asyncapi-config)
+  - [`asyncapi config analytics`](#asyncapi-config-analytics)
+  - [`asyncapi config context`](#asyncapi-config-context)
+  - [`asyncapi config context add CONTEXT-NAME SPEC-FILE-PATH`](#asyncapi-config-context-add-context-name-spec-file-path)
+  - [`asyncapi config context current`](#asyncapi-config-context-current)
+  - [`asyncapi config context edit CONTEXT-NAME NEW-SPEC-FILE-PATH`](#asyncapi-config-context-edit-context-name-new-spec-file-path)
+  - [`asyncapi config context init [CONTEXT-FILE-PATH]`](#asyncapi-config-context-init-context-file-path)
+  - [`asyncapi config context list`](#asyncapi-config-context-list)
+  - [`asyncapi config context remove CONTEXT-NAME`](#asyncapi-config-context-remove-context-name)
+  - [`asyncapi config context use CONTEXT-NAME`](#asyncapi-config-context-use-context-name)
+  - [`asyncapi config versions`](#asyncapi-config-versions)
+  - [`asyncapi convert [SPEC-FILE] [PROXYHOST] [PROXYPORT]`](#asyncapi-convert-spec-file-proxyhost-proxyport)
+  - [`asyncapi diff OLD NEW`](#asyncapi-diff-old-new)
+  - [`asyncapi format [SPEC-FILE]`](#asyncapi-format-spec-file)
+  - [`asyncapi generate`](#asyncapi-generate)
+  - [`asyncapi generate fromTemplate ASYNCAPI TEMPLATE`](#asyncapi-generate-fromtemplate-asyncapi-template)
+  - [`asyncapi generate models LANGUAGE FILE`](#asyncapi-generate-models-language-file)
+  - [`asyncapi new`](#asyncapi-new)
+  - [`asyncapi new file`](#asyncapi-new-file)
+  - [`asyncapi new glee`](#asyncapi-new-glee)
+  - [`asyncapi new template`](#asyncapi-new-template)
+  - [`asyncapi optimize [SPEC-FILE] [PROXYHOST] [PROXYPORT]`](#asyncapi-optimize-spec-file-proxyhost-proxyport)
+  - [`asyncapi pretty SPEC-FILE`](#asyncapi-pretty-spec-file)
+  - [`asyncapi start`](#asyncapi-start)
+  - [`asyncapi start studio`](#asyncapi-start-studio)
+  - [`asyncapi validate [SPEC-FILE] [PROXYHOST] [PROXYPORT]`](#asyncapi-validate-spec-file-proxyhost-proxyport)
 
 ## `asyncapi bundle`
 
@@ -786,10 +788,12 @@ starts a new local instance of Studio
 
 ```
 USAGE
-  $ asyncapi start studio [-h] [-f <value>] [-p <value>]
+  $ asyncapi start studio [SPEC_FILE] [-h] [-p <value>]
+
+ARGUMENTS
+  SPEC-FILE  spec path, url, or context-name
 
 FLAGS
-  -f, --file=<value>  path to the AsyncAPI file to link with Studio
   -h, --help          Show CLI help.
   -p, --port=<value>  port in which to start Studio
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/cli",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/cli",
-      "version": "2.14.1",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.23",
@@ -3690,6 +3690,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/commands/start/studio.ts
+++ b/src/commands/start/studio.ts
@@ -2,20 +2,35 @@ import Command from '../../core/base';
 import { start as startStudio } from '../../core/models/Studio';
 import { load } from '../../core/models/SpecificationFile';
 import { studioFlags } from '../../core/flags/start/studio.flags';
+import { Args } from '@oclif/core';
 
 export default class StartStudio extends Command {
   static description = 'starts a new local instance of Studio';
 
   static flags = studioFlags();
 
-  async run() {
-    const { flags } = await this.parse(StartStudio);
-    const filePath = flags.file || (await load()).getFilePath();
-    const port = flags.port;
-    
-    this.specFile = await load(filePath);
-    this.metricsMetadata.port = port;
+  static args = {
+    'spec-file': Args.string({ description: 'spec path, url, or context-name', required: false }),
+  };
 
+  async run() {
+    const { args, flags } = await this.parse(StartStudio);
+    let filePath = args['spec-file'];
+    const port = flags.port;
+    if (!filePath) {
+      try {
+        filePath = ((await load()).getFilePath());
+        this.log(`Loaded specification from: ${filePath}`);
+      } catch (error) {
+        this.log('No file specified. Starting with an empty Studio.');
+      }
+    }
+    try {
+      this.specFile = await load(filePath);
+    } catch (error) {
+      filePath = "";
+    }
+    this.metricsMetadata.port = port;
     startStudio(filePath as string, port);
   }
 }

--- a/src/commands/start/studio.ts
+++ b/src/commands/start/studio.ts
@@ -9,7 +9,7 @@ export default class StartStudio extends Command {
 
   static flags = studioFlags();
 
-  static args = {
+  static readonly args = {
     'spec-file': Args.string({ description: 'spec path, url, or context-name', required: false }),
   };
 
@@ -22,13 +22,16 @@ export default class StartStudio extends Command {
         filePath = ((await load()).getFilePath());
         this.log(`Loaded specification from: ${filePath}`);
       } catch (error) {
-        this.log('No file specified. Starting with an empty Studio.');
+        filePath = "";
+        this.log('No file specified.');
       }
     }
     try {
       this.specFile = await load(filePath);
     } catch (error) {
-      filePath = "";
+      if(filePath){
+        this.error(error as Error);
+      }
     }
     this.metricsMetadata.port = port;
     startStudio(filePath as string, port);

--- a/src/commands/start/studio.ts
+++ b/src/commands/start/studio.ts
@@ -22,14 +22,14 @@ export default class StartStudio extends Command {
         filePath = ((await load()).getFilePath());
         this.log(`Loaded specification from: ${filePath}`);
       } catch (error) {
-        filePath = "";
+        filePath = '';
         this.log('No file specified.');
       }
     }
     try {
       this.specFile = await load(filePath);
     } catch (error) {
-      if(filePath){
+      if (filePath) {
         this.error(error as Error);
       }
     }

--- a/src/core/flags/start/studio.flags.ts
+++ b/src/core/flags/start/studio.flags.ts
@@ -3,7 +3,6 @@ import { Flags } from '@oclif/core';
 export const studioFlags = () => {
   return {
     help: Flags.help({ char: 'h' }),
-    file: Flags.string({ char: 'f', description: 'path to the AsyncAPI file to link with Studio' }),
     port: Flags.integer({ char: 'p', description: 'port in which to start Studio' }),
   };
 };

--- a/src/core/models/Studio.ts
+++ b/src/core/models/Studio.ts
@@ -27,23 +27,23 @@ export function start(filePath: string, port: number = DEFAULT_PORT): void {
   if (filePath) {
     chokidar.watch(filePath).on('all', (event, path) => {
       switch (event) {
-        case 'add':
-        case 'change':
-          getFileContent(path).then((code: string) => {
-            messageQueue.push(JSON.stringify({
-              type: 'file:changed',
-              code,
-            }));
-            sendQueuedMessages();
-          });
-          break;
-        case 'unlink':
+      case 'add':
+      case 'change':
+        getFileContent(path).then((code: string) => {
           messageQueue.push(JSON.stringify({
-            type: 'file:deleted',
-            filePath,
+            type: 'file:changed',
+            code,
           }));
           sendQueuedMessages();
-          break;
+        });
+        break;
+      case 'unlink':
+        messageQueue.push(JSON.stringify({
+          type: 'file:deleted',
+          filePath,
+        }));
+        sendQueuedMessages();
+        break;
       }
     });
   }
@@ -81,8 +81,7 @@ export function start(filePath: string, port: number = DEFAULT_PORT): void {
         }));
         sendQueuedMessages();
       });
-    }
-    else{
+    } else {
       messageQueue.push(JSON.stringify({
         type: 'file:loaded',
         code: '',
@@ -115,8 +114,7 @@ export function start(filePath: string, port: number = DEFAULT_PORT): void {
     console.log(`You can open this URL in your web browser, and if needed, press ${gray('Ctrl + C')} to stop the process.`);
     if (filePath) {
       console.log(`Watching changes on file ${filePath}`);
-    } 
-    else{
+    } else {
       console.log(
         'Hint : No file was provided, and we couldn\'t find a default file (like "asyncapi.yaml" or "asyncapi.json") in the current folder. Starting Studio with a blank workspace.'
       );

--- a/src/core/models/Studio.ts
+++ b/src/core/models/Studio.ts
@@ -21,30 +21,32 @@ function isValidFilePath(filePath: string): boolean {
 }
 
 export function start(filePath: string, port: number = DEFAULT_PORT): void {
-  if (!isValidFilePath(filePath)) {
+  if (filePath && !isValidFilePath(filePath)) {
     throw new SpecificationFileNotFound(filePath);
   }
-  chokidar.watch(filePath).on('all', (event, path) => {
-    switch (event) {
-    case 'add':
-    case 'change':
-      getFileContent(path).then((code:string) => {
-        messageQueue.push(JSON.stringify({
-          type: 'file:changed',
-          code,
-        }));
-        sendQueuedMessages();
-      });
-      break;
-    case 'unlink':
-      messageQueue.push(JSON.stringify({
-        type: 'file:deleted',
-        filePath,
-      }));
-      sendQueuedMessages();
-      break;
-    }
-  });
+  if (filePath) {
+    chokidar.watch(filePath).on('all', (event, path) => {
+      switch (event) {
+        case 'add':
+        case 'change':
+          getFileContent(path).then((code: string) => {
+            messageQueue.push(JSON.stringify({
+              type: 'file:changed',
+              code,
+            }));
+            sendQueuedMessages();
+          });
+          break;
+        case 'unlink':
+          messageQueue.push(JSON.stringify({
+            type: 'file:deleted',
+            filePath,
+          }));
+          sendQueuedMessages();
+          break;
+      }
+    });
+  }
 
   const server = createServer((request, response) => {
     //not all CLI users use npm. Some package managers put dependencies in different weird places
@@ -71,18 +73,27 @@ export function start(filePath: string, port: number = DEFAULT_PORT): void {
 
   wsServer.on('connection', (socket: any) => {
     sockets.push(socket);
-    getFileContent(filePath).then((code: string) => {
+    if (filePath) {
+      getFileContent(filePath).then((code: string) => {
+        messageQueue.push(JSON.stringify({
+          type: 'file:loaded',
+          code,
+        }));
+        sendQueuedMessages();
+      });
+    }
+    else{
       messageQueue.push(JSON.stringify({
         type: 'file:loaded',
-        code,
+        code: '',
       }));
       sendQueuedMessages();
-    });
+    }
 
     socket.on('message', (event: string) => {
       try {
-        const json:any = JSON.parse(event);
-        if (json.type === 'file:update') {
+        const json: any = JSON.parse(event);
+        if (filePath && json.type === 'file:update') {
           saveFileContent(filePath, json.code);
         } else {
           console.warn('Live Server: An unknown event has been received. See details:');
@@ -102,7 +113,14 @@ export function start(filePath: string, port: number = DEFAULT_PORT): void {
     const url = `http://localhost:${port}?liveServer=${port}&studio-version=${studioVersion}`;
     console.log(`Studio is now running at ${url}.`);
     console.log(`You can open this URL in your web browser, and if needed, press ${gray('Ctrl + C')} to stop the process.`);
-    console.log(`Watching changes on file ${filePath}`);
+    if (filePath) {
+      console.log(`Watching changes on file ${filePath}`);
+    } 
+    else{
+      console.log(
+        'Hint : No file was provided, and we couldn\'t find a default file (like "asyncapi.yaml" or "asyncapi.json") in the current folder. Starting Studio with a blank workspace.'
+      );
+    }
     open(url);
   });
 }


### PR DESCRIPTION
**Description**
Remove -f flag from asyncapi start command 
asyncapi start command can now work without filename also

Fixes #1623 

Case 1 Filename given in command by user.
![Screenshot 2025-01-20 200812](https://github.com/user-attachments/assets/8c053de6-8cf1-4c90-bc45-40fe4850998f)

Case 2 Filename not given in command by user but asyncapi.yaml default file is present in current working directory.
![Screenshot 2025-01-20 200724](https://github.com/user-attachments/assets/32461296-412b-421a-bf63-e9261bc048fa)

Case 3 Filename not given in command by user and asyncapi.yaml default file is not present in current working directory. Open studio with empty file.
![Screenshot 2025-01-20 200949](https://github.com/user-attachments/assets/5ea5bf41-338a-46ad-9942-09f6388f71db)

Studio for Case 3
![image](https://github.com/user-attachments/assets/25381eae-e474-4193-b137-ba589ce33090)