### PR TITLE
chore: change the implementation of new command

### DIFF
--- a/.changeset/cuddly-files-move.md
+++ b/.changeset/cuddly-files-move.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+feat: change the implementation of new command

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -537,58 +537,15 @@ _See code: [src/commands/generate/models.ts](https://github.com/asyncapi/cli/blo
 
 ## `asyncapi new`
 
-Creates a new asyncapi file
+Create a new AsyncAPI project, specification files, or templates for clients and applications.
 
 ```
 USAGE
-  $ asyncapi new [-h] [-n <value>] [-e <value>] [-s] [-p <value>] [--no-tty]
-
-FLAGS
-  -e, --example=<value>
-      name of the example to use. Available examples are:
-      - simple-asyncapi.yml
-      - adeo-kafka-request-reply-asyncapi.yml
-      - anyof-asyncapi.yml
-      - application-headers-asyncapi.yml
-      - correlation-id-asyncapi.yml
-      - websocket-gemini-asyncapi.yml
-      - gitter-streaming-asyncapi.yml
-      - kraken-websocket-request-reply-message-filter-in-reply-asyncapi.yml
-      - kraken-websocket-request-reply-multiple-channels-asyncapi.yml
-      - mercure-asyncapi.yml
-      - not-asyncapi.yml
-      - operation-security-asyncapi.yml
-      - oneof-asyncapi.yml
-      - rpc-client-asyncapi.yml
-      - rpc-server-asyncapi.yml
-      - slack-rtm-asyncapi.yml
-      - tutorial.yml
-      - streetlights-kafka-asyncapi.yml
-      - streetlights-operation-security-asyncapi.yml
-      - streetlights-mqtt-asyncapi.yml
-
-  -h, --help
-      Show CLI help.
-
-  -n, --file-name=<value>
-      name of the file
-
-  -p, --port=<value>
-      port in which to start Studio
-
-  -s, --studio
-      open in Studio
-
-  --no-tty
-      do not use an interactive terminal
+  $ asyncapi new
 
 DESCRIPTION
-  Creates a new asyncapi file
+  Create a new AsyncAPI project, specification files, or templates for clients and applications.
 
-EXAMPLES
-  $ asyncapi new	 - start creation of a file in interactive mode
-
-  $ asyncapi new --file-name=my-asyncapi.yaml --example=default-example.yaml --no-tty	 - create a new file with a specific name, using one of the examples and without interactive mode
 ```
 
 _See code: [src/commands/new/index.ts](https://github.com/asyncapi/cli/blob/v2.14.1/src/commands/new/index.ts)_

--- a/src/commands/new/index.ts
+++ b/src/commands/new/index.ts
@@ -2,7 +2,7 @@ import Command from '../../core/base';
 import { Help } from '@oclif/core';
 
 export default class New extends Command {
-  static description = 'Create a new AsyncAPI project, specification files, or templates for clients and applications.';
+  static readonly description = 'Create a new AsyncAPI project, specification files, or templates for clients and applications.';
   async run() {
     const help = new Help(this.config);
     help.showHelp(['new', '--help']);

--- a/src/commands/new/index.ts
+++ b/src/commands/new/index.ts
@@ -1,3 +1,10 @@
-import File from './file';
+import Command from '../../core/base';
+import { Help } from '@oclif/core';
 
-export default class New extends File {}
+export default class New extends Command {
+  static description = 'Create a new AsyncAPI project, specification files, or templates for clients and applications.';
+  async run() {
+    const help = new Help(this.config);
+    help.showHelp(['new', '--help']);
+  }
+}

--- a/test/integration/new/file.test.ts
+++ b/test/integration/new/file.test.ts
@@ -5,31 +5,11 @@ import { expect } from '@oclif/test';
 const testHelper = new TestHelper();
 
 describe('new', () => {
-  before(() => {
-    try {
-      testHelper.deleteSpecFileAtWorkingDir();
-    } catch (e: any) {
-      if (e.code !== 'ENOENT') {
-        throw e;
-      }
-    }
-  });
-
   describe('create new file', () => {
     afterEach(() => {
       testHelper.deleteSpecFileAtWorkingDir();
     });
     
-    test
-      .stderr()
-      .stdout()
-      .command(['new', '--no-tty', '-n=specification.yaml'])
-      .it('runs new command', async (ctx,done) => {
-        expect(ctx.stderr).to.equal('');
-        expect(ctx.stdout).to.equal('The specification.yaml has been successfully created.\n');
-        done();
-      });
-
     test
       .stderr()
       .stdout()

--- a/test/integration/new/file.test.ts
+++ b/test/integration/new/file.test.ts
@@ -5,6 +5,16 @@ import { expect } from '@oclif/test';
 const testHelper = new TestHelper();
 
 describe('new', () => {
+  before(() => {
+    try {
+      testHelper.deleteSpecFileAtWorkingDir();
+    } catch (e: any) {
+      if (e.code !== 'ENOENT') {
+        throw e;
+      }
+    }
+  });
+  
   describe('create new file', () => {
     afterEach(() => {
       testHelper.deleteSpecFileAtWorkingDir();


### PR DESCRIPTION
**Description**
Made `asyncapi new` command consistent with other commands like `asyncapi generate`.

![image](https://github.com/user-attachments/assets/0398b6be-174c-4a41-9289-dc6d335510e8)

**Related issue(s)**
Fixes: #1647 