### PR TITLE
fix: starting of studio fixed when using example with new file

### DIFF
--- a/.changeset/wild-rockets-care.md
+++ b/.changeset/wild-rockets-care.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: starting of studio fixed when using example with new file

--- a/src/commands/new/file.ts
+++ b/src/commands/new/file.ts
@@ -127,6 +127,7 @@ export default class NewFile extends Command {
     selectedTemplate = selectedTemplate || DEFAULT_ASYNCAPI_TEMPLATE;
 
     await this.createAsyncapiFile(fileName, selectedTemplate);
+    fileName = fileName.includes('.') ? fileName : `${fileName}.yaml`;
     if (openStudio) { startStudio(fileName, flags.port || DEFAULT_PORT);}
   }
 


### PR DESCRIPTION
**Description**

This PR introduces the changes to fix the starting of studio when used with an example while creating a new file.

Approach:-
Upon debugging found that to start studio the extension had also to be passed with file name so that was added to be passed if not passed by default. `yaml` was passed as it was default extension used by cli when creation of files if no extension is specified.

**Related issue(s)**
Resolves #1648 