### PR TITLE
ci: add changeset automation

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -1,0 +1,58 @@
+name: Add changeset automatically
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      
+# startsWith(github.repository, 'asyncapi/') &&
+jobs:
+  auto-changeset:
+    if: |
+      ( startsWith(github.event.pull_request.title, 'fix:') ||
+        startsWith(github.event.pull_request.title, 'feat:') ||
+        startsWith(github.event.pull_request.title, 'fix!:') ||
+        startsWith(github.event.pull_request.title, 'feat!:')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Checkout PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: gh pr checkout ${{ github.event.pull_request.number }}
+      - name: Determine release type
+        id: determine_release_type
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const releaseType = title.split(':')[0];
+            switch (releaseType) {
+              case 'fix':
+                return 'patch';
+              case 'feat':
+                return 'minor';
+              case 'fix!':
+                return 'major';
+              case 'feat!':
+                return 'major';
+              default:
+                return 'patch';
+            }
+      - name: Create changeset file
+        run: "echo -e '---\n'@asyncapi/cli': ${{ steps.determine_release_type.outputs.result }}\n---\n\n ${{ github.event.pull_request.title }}\n\n' > .changeset/${{ github.event.pull_request.number }}.md"
+      - name: Commit changeset file
+        run: |
+          git config --global user.email "info@asyncapi.com"
+          git config --global user.name "asyncapi-bot"
+          git add .changeset/${{ github.event.pull_request.number }}.md
+          git commit -m "chore: add changeset for PR #${{ github.event.pull_request.number }}"
+      # - name: Debug event
+      #   run: echo ${{ toJson(github.event) }}
+      - name: Push changeset file
+        run: git push https://${{ secrets.GH_TOKEN }}@github.com/${{ github.event.pull_request.head.repo.full_name }} HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -6,10 +6,10 @@ on:
       - opened
       - edited
       
-# startsWith(github.repository, 'asyncapi/') &&
 jobs:
   auto-changeset:
     if: |
+      startsWith(github.repository, 'asyncapi/') &&
       ( startsWith(github.event.pull_request.title, 'fix:') ||
         startsWith(github.event.pull_request.title, 'feat:') ||
         startsWith(github.event.pull_request.title, 'fix!:') ||
@@ -21,10 +21,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
+
       - name: Checkout PR
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: gh pr checkout ${{ github.event.pull_request.number }}
+
       - name: Determine release type
         id: determine_release_type
         uses: actions/github-script@v7
@@ -44,15 +46,27 @@ jobs:
               default:
                 return 'patch';
             }
+
       - name: Create changeset file
-        run: "echo -e '---\n'@asyncapi/cli': ${{ steps.determine_release_type.outputs.result }}\n---\n\n ${{ github.event.pull_request.title }}\n\n' > .changeset/${{ github.event.pull_request.number }}.md"
+        run: "echo -e '---\n'@asyncapi/cli': ${{ steps.determine_release_type.outputs.result }}\n---\n\n ${{ github.event.pull_request.title }}\n' > .changeset/${{ github.event.pull_request.number }}.md"
+
       - name: Commit changeset file
         run: |
-          git config --global user.email "info@asyncapi.com"
-          git config --global user.name "asyncapi-bot"
+          git config --global user.name asyncapi-bot
+          git config --global user.email info@asyncapi.io
           git add .changeset/${{ github.event.pull_request.number }}.md
           git commit -m "chore: add changeset for PR #${{ github.event.pull_request.number }}"
-      # - name: Debug event
-      #   run: echo ${{ toJson(github.event) }}
+
       - name: Push changeset file
         run: git push https://${{ secrets.GH_TOKEN }}@github.com/${{ github.event.pull_request.head.repo.full_name }} HEAD:${{ github.event.pull_request.head.ref }}
+
+      # Only, on failure, send a message on the 94_bot-failing-ci slack channel
+      - if: failure()
+        name: Report workflow run status to Slack
+        uses: 8398a7/action-slack@fbd6aa58ba854a740e11a35d0df80cb5d12101d8 #using https://github.com/8398a7/action-slack/releases/tag/v3.15.1
+        with:
+          status: ${{ job.status }}
+          fields: repo,action,workflow
+          text: 'AsyncAPI CLI release to Chocolatey failed'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}

--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -1,20 +1,25 @@
-name: Add changeset automatically
+name: Changeset Automation
 
 on:
   pull_request_target:
     types:
       - opened
       - edited
-      
+      - synchronize
+      - reopened
+      - ready_for_review
+
 jobs:
   auto-changeset:
+    #  TODO: remove true after testing is done
     if: |
       startsWith(github.repository, 'asyncapi/') &&
+      (!contains(github.event.pull_request.labels, 'skip-changeset')) &&
       ( startsWith(github.event.pull_request.title, 'fix:') ||
         startsWith(github.event.pull_request.title, 'feat:') ||
         startsWith(github.event.pull_request.title, 'fix!:') ||
         startsWith(github.event.pull_request.title, 'feat!:')
-      )
+      ) || true 
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -27,46 +32,48 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: gh pr checkout ${{ github.event.pull_request.number }}
 
-      - name: Determine release type
-        id: determine_release_type
+      - name: Install dependencies
+        run: npm install read-package-up
+
+      - name: Get changeset contents
+        id: get_changeset_contents
         uses: actions/github-script@v7
         with:
           script: |
-            const title = context.payload.pull_request.title;
-            const releaseType = title.split(':')[0];
-            switch (releaseType) {
-              case 'fix':
-                return 'patch';
-              case 'feat':
-                return 'minor';
-              case 'fix!':
-                return 'major';
-              case 'feat!':
-                return 'major';
-              default:
-                return 'patch';
-            }
+            const { getChangesetContents } = require('./.github/workflows/changeset-utils/index.js')            
+            const pullRequest = context.payload.pull_request;
+            const changesetContents = await getChangesetContents(pullRequest, github)
+            return changesetContents;
 
       - name: Create changeset file
-        run: "echo -e '---\n'@asyncapi/cli': ${{ steps.determine_release_type.outputs.result }}\n---\n\n ${{ github.event.pull_request.title }}\n' > .changeset/${{ github.event.pull_request.number }}.md"
+        run: "echo -e ${{ steps.get_changeset_contents.outputs.result }} > .changeset/${{ github.event.pull_request.number }}.md"
 
       - name: Commit changeset file
         run: |
           git config --global user.name asyncapi-bot
           git config --global user.email info@asyncapi.io
           git add .changeset/${{ github.event.pull_request.number }}.md
-          git commit -m "chore: add changeset for PR #${{ github.event.pull_request.number }}"
+          # Check if there are any changes to commit
+          if git diff --quiet HEAD; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: add changeset for PR #${{ github.event.pull_request.number }}"
+          fi
 
       - name: Push changeset file
-        run: git push https://${{ secrets.GH_TOKEN }}@github.com/${{ github.event.pull_request.head.repo.full_name }} HEAD:${{ github.event.pull_request.head.ref }}
-
-      # Only, on failure, send a message on the 94_bot-failing-ci slack channel
-      - if: failure()
-        name: Report workflow run status to Slack
-        uses: 8398a7/action-slack@fbd6aa58ba854a740e11a35d0df80cb5d12101d8 #using https://github.com/8398a7/action-slack/releases/tag/v3.15.1
-        with:
-          status: ${{ job.status }}
-          fields: repo,action,workflow
-          text: 'AsyncAPI CLI release to Chocolatey failed'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          git remote set-url origin https://github.com/${{ github.event.pull_request.head.repo.full_name }}
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+      
+      - name: Comment workflow
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { commentWorkflow } = require('./.github/workflows/changeset-utils/index.js')
+            const pullRequest = context.payload.pull_request;
+            const changesetContents = ${{ steps.get_changeset_contents.outputs.result }}
+            await commentWorkflow(pullRequest, github, changesetContents)

--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -31,8 +31,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: gh pr checkout ${{ github.event.pull_request.number }}
 
-      - name: Install dependencies
-        run: npm install read-package-up
+      - name: Install specific package in temp dir
+        run: |
+          mkdir temp-install
+          cd temp-install
+          npm init -y
+          npm install read-package-up@11.0.0
+          cp -r node_modules ../node_modules
+          cd ..
+          rm -rf temp-install
 
       - name: Get changeset contents
         id: get_changeset_contents

--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -31,6 +31,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: gh pr checkout ${{ github.event.pull_request.number }}
 
+      # This step has been added in such a way because
+      # - Using simple `npm install` will install all the packages in the repo, which takes a lot of time.
+      # - Using `npm install` doesn't work with all repositories, as some of them have a different structure/package manager.
+      # - Global installation also doesn't work as can't be imported in the script.
       - name: Install specific package in temp dir
         run: |
           mkdir temp-install

--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   auto-changeset:
-    #  TODO: remove true after testing is done
     if: |
       startsWith(github.repository, 'asyncapi/') &&
       (!contains(github.event.pull_request.labels, 'skip-changeset')) &&
@@ -19,7 +18,7 @@ jobs:
         startsWith(github.event.pull_request.title, 'feat:') ||
         startsWith(github.event.pull_request.title, 'fix!:') ||
         startsWith(github.event.pull_request.title, 'feat!:')
-      ) || true 
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/changeset-utils/index.js
+++ b/.github/workflows/changeset-utils/index.js
@@ -97,7 +97,7 @@ const getChangesetContents = async (pullRequest, github) => {
  * If it is already created, it updates the comment with the new changeset.
  */
 const commentWorkflow = async (pullRequest, github, changesetContents) => {
-  const body = `#### Changeset has been generated for this PR as part of auto-changeset workflow.\n\n<details><summary>Please review the changeset before merging the PR.</summary>\n\n\`\`\`\n${changesetContents}\`\`\`\n\n</details>\n\n[If you are a maintainer or the author of the PR, you can change the changeset by clicking here](https://github.com/${pullRequest.head.repo.full_name}/edit/${pullRequest.head.ref}/.changeset/${pullRequest.number}.md)`
+  const body = `#### Changeset has been generated for this PR as part of auto-changeset workflow.\n\n<details><summary>Please review the changeset before merging the PR.</summary>\n\n\`\`\`\n${changesetContents}\`\`\`\n\n</details>\n\n[If you are a maintainer or the author of the PR, you can change the changeset by clicking here](https://github.com/${pullRequest.head.repo.full_name}/edit/${pullRequest.head.ref}/.changeset/${pullRequest.number}.md)\n\n> [!TIP] If you don't want auto-changeset to run on this PR, you can add the label \`skip-changeset\` to the PR.`
 
   const comments = await github.rest.issues.listComments({
     owner: pullRequest.base.repo.owner.login,

--- a/.github/workflows/changeset-utils/index.js
+++ b/.github/workflows/changeset-utils/index.js
@@ -104,7 +104,7 @@ const getChangesetContents = async (pullRequest, github) => {
  * If it is already created, it updates the comment with the new changeset.
  */
 const commentWorkflow = async (pullRequest, github, changesetContents) => {
-  const body = `#### Changeset has been generated for this PR as part of auto-changeset workflow.\n\n<details><summary>Please review the changeset before merging the PR.</summary>\n\n\`\`\`\n${changesetContents}\`\`\`\n\n</details>\n\n[If you are a maintainer or the author of the PR, you can change the changeset by clicking here](https://github.com/${pullRequest.head.repo.full_name}/edit/${pullRequest.head.ref}/.changeset/${pullRequest.number}.md)\n\n> [!TIP]\n> If you don't want auto-changeset to run on this PR, you can add the label \`skip-changeset\` to the PR.`
+  const body = `#### Changeset has been generated for this PR as part of auto-changeset workflow.\n\n<details><summary>Please review the changeset before merging the PR.</summary>\n\n\`\`\`\n${changesetContents}\`\`\`\n\n</details>\n\n[If you are a maintainer or the author of the PR, you can change the changeset by clicking here](https://github.com/${pullRequest.head.repo.full_name}/edit/${pullRequest.head.ref}/.changeset/${pullRequest.number}.md)\n\n> [!TIP]\n> If you don't want auto-changeset to run on this PR, you can add the label \`skip-changeset\` to the PR or remove the changeset and change PR title to something other than \`fix:\` or \`feat:\`.`;
 
   const comments = await github.rest.issues.listComments({
     owner: pullRequest.base.repo.owner.login,

--- a/.github/workflows/changeset-utils/index.js
+++ b/.github/workflows/changeset-utils/index.js
@@ -1,0 +1,130 @@
+const path = require('path');
+const { readPackageUp } = require('read-package-up');
+
+// @todo
+// Check if maintainer can modify the head
+
+const getFormattedCommits = async (pullRequest, github) => {
+  const commitOpts = github.rest.pulls.listCommits.endpoint.merge({
+    owner: pullRequest.base.repo.owner.login,
+    repo: pullRequest.base.repo.name,
+    pull_number: pullRequest.number,
+  });
+
+  const commits = await github.paginate(commitOpts);
+
+  // Filter merge commits and commits by asyncapi-bot
+  const filteredCommits = commits.filter((commit) => {
+    return !commit.commit.message.startsWith('Merge pull request') && !commit.commit.message.startsWith('Merge branch') && !commit.commit.author.name.startsWith('asyncapi-bot') && !commit.commit.author.name.startsWith('dependabot[bot]');
+  });
+
+  return filteredCommits.map((commit) => {
+    return {
+      commit_sha: commit.sha.slice(0, 7), // first 7 characters of the commit sha is enough to identify the commit
+      commit_message: commit.commit.message,
+    };
+  });
+}
+
+const getReleasedPackages = async (pullRequest, github) => {
+  const files = await github.paginate(github.rest.pulls.listFiles.endpoint.merge({
+    owner: pullRequest.base.repo.owner.login,
+    repo: pullRequest.base.repo.name,
+    pull_number: pullRequest.number,
+  }));
+
+  const releasedPackages = [];
+  const ignoredFiles = ['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml'];
+  for (const file of files) {
+    if (!ignoredFiles.includes(file.filename)) {
+      const cwd = path.resolve(path.dirname(file.filename));
+      const { packageJson } = await readPackageUp(cwd);
+      if (!releasedPackages.includes(packageJson.name)) {
+        releasedPackages.push(packageJson.name);
+      }
+    } 
+  }
+
+  console.debug('Filenames', files.map((file) => file.filename));
+  return releasedPackages;
+}
+
+const getReleaseNotes = async (pullRequest, github) => {
+  const commits = await getFormattedCommits(pullRequest, github);
+  /**
+   * Release notes are generated from the commits.
+   * Format:
+   * - title
+   * - commit_sha: commit_message (Array of commits)
+   */
+  const releaseNotes = pullRequest.title + '\n\n' + commits.map((commit) => {
+    return `- ${commit.commit_sha}: ${commit.commit_message}`;
+  }).join('\n');
+
+  return releaseNotes;
+}
+
+const getChangesetContents = async (pullRequest, github) => {
+  const title = pullRequest.title;
+  const releaseType = title.split(':')[0];
+  let releaseVersion = 'patch';
+  switch (releaseType) {
+    case 'fix':
+      releaseVersion = 'patch';
+    case 'feat':
+      releaseVersion = 'minor';
+    case 'fix!':
+      releaseVersion = 'major';
+    case 'feat!':
+      releaseVersion = 'major';
+    default:
+      releaseVersion = 'patch';
+  }
+
+  const releaseNotes = await getReleaseNotes(pullRequest, github);
+  const releasedPackages = await getReleasedPackages(pullRequest, github);
+
+  const changesetContents = releasedPackages.map((pkg) => {
+    return `---\n'${pkg}': ${releaseVersion}\n`;
+  }).join('\n') + `---\n\n${releaseNotes}\n\n`
+
+  return changesetContents;
+};
+
+/**
+ * This function checks if a comment has already been created by the workflow.
+ * If not, it creates a comment with the changeset.
+ * If it is already created, it updates the comment with the new changeset.
+ */
+const commentWorkflow = async (pullRequest, github, changesetContents) => {
+  const body = `#### Changeset has been generated for this PR as part of auto-changeset workflow.\n\n<details><summary>Please review the changeset before merging the PR.</summary>\n\n\`\`\`\n${changesetContents}\`\`\`\n\n</details>\n\n[If you are a maintainer or the author of the PR, you can change the changeset by clicking here](https://github.com/${pullRequest.head.repo.full_name}/edit/${pullRequest.head.ref}/.changeset/${pullRequest.number}.md)`
+
+  const comments = await github.rest.issues.listComments({
+    owner: pullRequest.base.repo.owner.login,
+    repo: pullRequest.base.repo.name,
+    issue_number: pullRequest.number,
+  });
+
+  const comment = comments.data.find((comment) => comment.body.includes('Changeset has been generated for this PR as part of auto-changeset workflow.'));
+  if (comment) {
+    await github.rest.issues.updateComment({
+      owner: pullRequest.base.repo.owner.login,
+      repo: pullRequest.base.repo.name,
+      comment_id: comment.id,
+      body: body,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      owner: pullRequest.base.repo.owner.login,
+      repo: pullRequest.base.repo.name,
+      issue_number: pullRequest.number,
+      body: body,
+      user: 'asyncapi-bot',
+    });
+  }
+}
+
+module.exports = {
+  getChangesetContents,
+  commentWorkflow,
+};

--- a/temp-package.json
+++ b/temp-package.json
@@ -1,0 +1,1 @@
+{"dependencies":{"read-package-up":"11.0.0"}}

--- a/temp-package.json
+++ b/temp-package.json
@@ -1,1 +1,0 @@
-{"dependencies":{"read-package-up":"11.0.0"}}


### PR DESCRIPTION
**Description**

This pull request introduces an automated workflow for generating changesets for pull requests. The most important changes include the addition of a new GitHub Actions workflow and utility functions to handle changeset generation and commenting on pull requests.

### Changeset Automation Workflow:

* [`.github/workflows/auto-changeset.yml`](diffhunk://#diff-ff8bc9ad708f80ded673a997bad71c3771c8c1c1d0fc313cdf72d9c31e120e08R1-R79): Added a new workflow to automate changeset generation for pull requests with specific titles. This workflow runs on various pull request events and includes steps for checking out the repository, installing dependencies, generating changeset contents, creating and committing the changeset file, pushing the changeset file, and commenting on the pull request.

### Utility Functions for Changeset Generation:

* `.github/workflows/changeset-utils/index.js`: Added utility functions to:
  * Filter and format commits from a pull request.
  * Identify released packages by analyzing modified files.
  * Generate release notes from commit messages.
  * Create changeset contents based on the pull request title and release notes.
  * Comment on the pull request with the generated changeset, updating the comment if it already exists.

Workflows and proof: https://github.com/Shurtu-gal/action-test-bed/pull/8

**Related issue(s)**
Fixes #1652 