### PR TITLE
fix: print in cli  asyncapi generate models without -o flag

### DIFF
--- a/.changeset/sour-clouds-heal.md
+++ b/.changeset/sour-clouds-heal.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: print in cli  asyncapi generate models without -o flag

--- a/src/commands/generate/models.ts
+++ b/src/commands/generate/models.ts
@@ -58,7 +58,7 @@ export default class Models extends Command {
     s.start('Generating models...');
     try {
       const generatedModels = await generateModels({...flags, output}, document, logger, language as Languages);
-      if (output !== 'stdout') {
+      if (output && output !== 'stdout') {
         const generatedModelStrings = generatedModels.map((model) => { return model.modelName; });
         s.stop(green(`Successfully generated the following models: ${generatedModelStrings.join(', ')}`));
         return;

--- a/test/integration/generate/models.test.ts
+++ b/test/integration/generate/models.test.ts
@@ -24,12 +24,21 @@ describe('models', () => {
       );
       done();
     });
-
+  
+  test
+    .stderr()
+    .stdout()
+    .command([...generalOptions, 'typescript', './test/fixtures/specification.yml'])
+    .it('works when file path is passed without specified output directory', (ctx, done) => {
+      expect(ctx.stdout).to.match(/Successfully generated the following models:\s+## Model name:/);
+      done();
+    });
+  
   test
     .stderr()
     .stdout()
     .command([...generalOptions, 'typescript', './test/fixtures/specification.yml', `-o=${ path.resolve(outputDir, './ts')}`])
-    .it('works when file path is passed', (ctx, done) => {
+    .it('works when file path is passed with specified output directory', (ctx, done) => {
       expect(ctx.stdout).to.contain(
         'Successfully generated the following models: '
       );


### PR DESCRIPTION
**Description**

`asyncapi generate models LANGUAGE FILE` can print the output in CLI itself if `-o` flag is missing.

![image](https://github.com/user-attachments/assets/94f8dcc8-7a45-4af2-8a12-790bb04d0f8d)

**Related issue(s)**
Fixes: #1654 