### PR TITLE
fix: proxy implementation for optimize validate and convert fixed

### DIFF
--- a/.changeset/smooth-rabbits-occur.md
+++ b/.changeset/smooth-rabbits-occur.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: proxy implementation for optimize validate and convert fixed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,7 +52,7 @@ USAGE
   - [`asyncapi config context remove CONTEXT-NAME`](#asyncapi-config-context-remove-context-name)
   - [`asyncapi config context use CONTEXT-NAME`](#asyncapi-config-context-use-context-name)
   - [`asyncapi config versions`](#asyncapi-config-versions)
-  - [`asyncapi convert [SPEC-FILE]`](#asyncapi-convert-spec-file-proxyhost-proxyport)
+  - [`asyncapi convert [SPEC-FILE]`](#asyncapi-convert-spec-file)
   - [`asyncapi diff OLD NEW`](#asyncapi-diff-old-new)
   - [`asyncapi format [SPEC-FILE]`](#asyncapi-format-spec-file)
   - [`asyncapi generate`](#asyncapi-generate)
@@ -62,11 +62,11 @@ USAGE
   - [`asyncapi new file`](#asyncapi-new-file)
   - [`asyncapi new glee`](#asyncapi-new-glee)
   - [`asyncapi new template`](#asyncapi-new-template)
-  - [`asyncapi optimize [SPEC-FILE]`](#asyncapi-optimize-spec-file-proxyhost-proxyport)
+  - [`asyncapi optimize [SPEC-FILE]`](#asyncapi-optimize-spec-file)
   - [`asyncapi pretty SPEC-FILE`](#asyncapi-pretty-spec-file)
   - [`asyncapi start`](#asyncapi-start)
   - [`asyncapi start studio`](#asyncapi-start-studio)
-  - [`asyncapi validate [SPEC-FILE]`](#asyncapi-validate-spec-file-proxyhost-proxyport)
+  - [`asyncapi validate [SPEC-FILE]`](#asyncapi-validate-spec-file)
 
 ## `asyncapi bundle`
 
@@ -310,7 +310,7 @@ DESCRIPTION
 
 _See code: [src/commands/config/versions.ts](https://github.com/asyncapi/cli/blob/v2.14.1/src/commands/config/versions.ts)_
 
-## `asyncapi convert [SPEC-FILE] [PROXYHOST] [PROXYPORT]`
+## `asyncapi convert [SPEC-FILE]`
 
 Convert asyncapi documents older to newer versions or OpenAPI/postman-collection documents to AsyncAPI
 
@@ -662,7 +662,7 @@ optimize asyncapi specification file
 
 ```
 USAGE
-  $ asyncapi optimize [SPEC-FILE] [PROXYHOST] [PROXYPORT] [-h] [-p
+  $ asyncapi optimize [SPEC-FILE] [-h] [-p
     remove-components|reuse-components|move-duplicates-to-components|move-all-to-components...] [-i schema...] [-o
     terminal|new-file|overwrite] [--no-tty] [--proxyHost <value>] [--proxyPort <value>]
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,7 +52,7 @@ USAGE
   - [`asyncapi config context remove CONTEXT-NAME`](#asyncapi-config-context-remove-context-name)
   - [`asyncapi config context use CONTEXT-NAME`](#asyncapi-config-context-use-context-name)
   - [`asyncapi config versions`](#asyncapi-config-versions)
-  - [`asyncapi convert [SPEC-FILE] [PROXYHOST] [PROXYPORT]`](#asyncapi-convert-spec-file-proxyhost-proxyport)
+  - [`asyncapi convert [SPEC-FILE]`](#asyncapi-convert-spec-file-proxyhost-proxyport)
   - [`asyncapi diff OLD NEW`](#asyncapi-diff-old-new)
   - [`asyncapi format [SPEC-FILE]`](#asyncapi-format-spec-file)
   - [`asyncapi generate`](#asyncapi-generate)
@@ -62,11 +62,11 @@ USAGE
   - [`asyncapi new file`](#asyncapi-new-file)
   - [`asyncapi new glee`](#asyncapi-new-glee)
   - [`asyncapi new template`](#asyncapi-new-template)
-  - [`asyncapi optimize [SPEC-FILE] [PROXYHOST] [PROXYPORT]`](#asyncapi-optimize-spec-file-proxyhost-proxyport)
+  - [`asyncapi optimize [SPEC-FILE]`](#asyncapi-optimize-spec-file-proxyhost-proxyport)
   - [`asyncapi pretty SPEC-FILE`](#asyncapi-pretty-spec-file)
   - [`asyncapi start`](#asyncapi-start)
   - [`asyncapi start studio`](#asyncapi-start-studio)
-  - [`asyncapi validate [SPEC-FILE] [PROXYHOST] [PROXYPORT]`](#asyncapi-validate-spec-file-proxyhost-proxyport)
+  - [`asyncapi validate [SPEC-FILE]`](#asyncapi-validate-spec-file-proxyhost-proxyport)
 
 ## `asyncapi bundle`
 
@@ -316,13 +316,11 @@ Convert asyncapi documents older to newer versions or OpenAPI/postman-collection
 
 ```
 USAGE
-  $ asyncapi convert [SPEC-FILE] [PROXYHOST] [PROXYPORT] -f openapi|asyncapi|postman-collection [-h] [-o
+  $ asyncapi convert [SPEC-FILE] -f openapi|asyncapi|postman-collection [-h] [-o
     <value>] [-t <value>] [-p client|server] [--proxyHost <value>] [--proxyPort <value>]
 
 ARGUMENTS
   SPEC-FILE  spec path, url, or context-name
-  PROXYHOST  Name of the Proxy Host
-  PROXYPORT  Name of the Port of the ProxyHost
 
 FLAGS
   -f, --format=<option>         (required) [default: asyncapi] Specify the format to convert from (openapi or asyncapi)
@@ -658,7 +656,7 @@ DESCRIPTION
 
 _See code: [src/commands/new/template.ts](https://github.com/asyncapi/cli/blob/v2.14.1/src/commands/new/template.ts)_
 
-## `asyncapi optimize [SPEC-FILE] [PROXYHOST] [PROXYPORT]`
+## `asyncapi optimize [SPEC-FILE]`
 
 optimize asyncapi specification file
 
@@ -670,8 +668,6 @@ USAGE
 
 ARGUMENTS
   SPEC-FILE  spec path, url, or context-name
-  PROXYHOST  Name of the Proxy Host
-  PROXYPORT  Name of the Port of the ProxyHost
 
 FLAGS
   -h, --help                      Show CLI help.
@@ -764,20 +760,18 @@ DESCRIPTION
 
 _See code: [src/commands/start/studio.ts](https://github.com/asyncapi/cli/blob/v2.14.1/src/commands/start/studio.ts)_
 
-## `asyncapi validate [SPEC-FILE] [PROXYHOST] [PROXYPORT]`
+## `asyncapi validate [SPEC-FILE]`
 
 validate asyncapi file
 
 ```
 USAGE
-  $ asyncapi validate [SPEC-FILE] [PROXYHOST] [PROXYPORT] [-h] [-w] [--log-diagnostics] [--diagnostics-format
+  $ asyncapi validate [SPEC-FILE] [-h] [-w] [--log-diagnostics] [--diagnostics-format
     json|stylish|junit|html|text|teamcity|pretty] [--fail-severity error|warn|info|hint] [-o <value>] [--score]
     [--proxyHost <value>] [--proxyPort <value>]
 
 ARGUMENTS
   SPEC-FILE  spec path, url, or context-name
-  PROXYHOST  Name of the Proxy Host
-  PROXYPORT  Name of the Port of the ProxyHost
 
 FLAGS
   -h, --help                         Show CLI help.

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -28,8 +28,6 @@ export default class Convert extends Command {
 
   static args = {
     'spec-file': Args.string({description: 'spec path, url, or context-name', required: false}),
-    proxyHost: Args.string({description: 'Name of the Proxy Host', required: false}),
-    proxyPort: Args.string({description: 'Name of the Port of the ProxyHost', required: false}),
   };
 
   async run() {

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -50,8 +50,6 @@ export default class Optimize extends Command {
 
   static args = {
     'spec-file': Args.string({description: 'spec path, url, or context-name', required: false}),
-    proxyHost: Args.string({description: 'Name of the Proxy Host', required: false}),
-    proxyPort: Args.string({description: 'Name of the Port of the ProxyHost', required: false}),
   };
 
   parser = new Parser();

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -17,8 +17,6 @@ export default class Validate extends Command {
 
   static args = {
     'spec-file': Args.string({description: 'spec path, url, or context-name', required: false}),
-    proxyHost: Args.string({description: 'Name of the Proxy Host', required: false}),
-    proxyPort: Args.string({description: 'Name of the Port of the ProxyHost', required: false}),
   };
 
   async run() {


### PR DESCRIPTION
**Description**

This PR introduces the changes to remove`proxyHost` and `proxyPort` form the arguments of commands `optimize` , `validate` , `convert`.

Docs for the same are also updated.

`optimize`

![image](https://github.com/user-attachments/assets/405ac040-1a5e-4f76-bf48-8a66f45fc2f8)

`convert`

![image](https://github.com/user-attachments/assets/cffc8c72-31e8-4f45-b2b9-5a5dec8c22d2)

`validate`

![image](https://github.com/user-attachments/assets/a17a76e9-4890-469e-ab8d-4b3354f64088)

All tests are also passing

![image](https://github.com/user-attachments/assets/2e4999bf-6ed8-49e3-8493-440c15e6f4fc)




**Related issue(s)**
Resolves #1667 

@AayushSaini101 Please review and provide feedback.

Thanks