### PR TITLE
docs: inconsistent formatting asterisk-mark

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,9 +12,9 @@ The AsyncAPI CLI uses oclif (Open CLI Framework) as its core framework, which en
 
 ---
 
-### **Detailed Explanation of Key Directories in the CLI**
+### Detailed Explanation of Key Directories in the CLI
 
-#### **`src/commands/`**
+#### `src/commands/`
 - **Purpose:** Implements the CLI commands available to the user.
 - **Subdirectories:**
   - `config/`: Stores configuration-related files for commands.
@@ -42,7 +42,7 @@ The AsyncAPI CLI uses oclif (Open CLI Framework) as its core framework, which en
 
 ---
 
-#### **`src/core/`**
+#### `src/core/`
 - **Purpose:** Provides foundational components and utilities for the CLI.
 - **Subdirectories:**
   - `errors/`: Centralized error definitions.
@@ -59,7 +59,7 @@ The AsyncAPI CLI uses oclif (Open CLI Framework) as its core framework, which en
 
 ---
 
-#### **`test/`**
+#### `test/`
 - **Purpose:** Implements the test suite for the CLI.
 - **Subdirectories:**
   - `fixtures/`: Contains mock data or files for testing.
@@ -70,7 +70,7 @@ The AsyncAPI CLI uses oclif (Open CLI Framework) as its core framework, which en
 
 ---
 
-### **Use Cases**
+### Use Cases
 
 1. **Generate AsyncAPI Artifacts:**
    - Use the `generate` command to create client/server code, documentation, or other artifacts based on AsyncAPI templates.


### PR DESCRIPTION
**Description**
On the [page](https://www.asyncapi.com/docs/tools/cli/architecture) extra (*) is shown. The issue was create in asyncapi/website and after approval I created the PR.

**Related issue(s)**
fixes: [#3643](https://github.com/asyncapi/website/issues/3643)