### PR TITLE
feat: asyncapi generate fromTemplate can now work in interactive mode

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,33 +38,35 @@ USAGE
 # Commands
 
 <!-- commands -->
-* [`asyncapi bundle`](#asyncapi-bundle)
-* [`asyncapi config`](#asyncapi-config)
-* [`asyncapi config analytics`](#asyncapi-config-analytics)
-* [`asyncapi config context`](#asyncapi-config-context)
-* [`asyncapi config context add CONTEXT-NAME SPEC-FILE-PATH`](#asyncapi-config-context-add-context-name-spec-file-path)
-* [`asyncapi config context current`](#asyncapi-config-context-current)
-* [`asyncapi config context edit CONTEXT-NAME NEW-SPEC-FILE-PATH`](#asyncapi-config-context-edit-context-name-new-spec-file-path)
-* [`asyncapi config context init [CONTEXT-FILE-PATH]`](#asyncapi-config-context-init-context-file-path)
-* [`asyncapi config context list`](#asyncapi-config-context-list)
-* [`asyncapi config context remove CONTEXT-NAME`](#asyncapi-config-context-remove-context-name)
-* [`asyncapi config context use CONTEXT-NAME`](#asyncapi-config-context-use-context-name)
-* [`asyncapi config versions`](#asyncapi-config-versions)
-* [`asyncapi convert [SPEC-FILE]`](#asyncapi-convert-spec-file)
-* [`asyncapi diff OLD NEW`](#asyncapi-diff-old-new)
-* [`asyncapi format [SPEC-FILE]`](#asyncapi-format-spec-file)
-* [`asyncapi generate`](#asyncapi-generate)
-* [`asyncapi generate fromTemplate ASYNCAPI TEMPLATE`](#asyncapi-generate-fromtemplate-asyncapi-template)
-* [`asyncapi generate models LANGUAGE FILE`](#asyncapi-generate-models-language-file)
-* [`asyncapi new`](#asyncapi-new)
-* [`asyncapi new file`](#asyncapi-new-file)
-* [`asyncapi new glee`](#asyncapi-new-glee)
-* [`asyncapi new template`](#asyncapi-new-template)
-* [`asyncapi optimize [SPEC-FILE]`](#asyncapi-optimize-spec-file)
-* [`asyncapi pretty SPEC-FILE`](#asyncapi-pretty-spec-file)
-* [`asyncapi start`](#asyncapi-start)
-* [`asyncapi start studio [SPEC-FILE]`](#asyncapi-start-studio-spec-file)
-* [`asyncapi validate [SPEC-FILE]`](#asyncapi-validate-spec-file)
+- [Usage](#usage)
+- [Commands](#commands)
+  - [`asyncapi bundle`](#asyncapi-bundle)
+  - [`asyncapi config`](#asyncapi-config)
+  - [`asyncapi config analytics`](#asyncapi-config-analytics)
+  - [`asyncapi config context`](#asyncapi-config-context)
+  - [`asyncapi config context add CONTEXT-NAME SPEC-FILE-PATH`](#asyncapi-config-context-add-context-name-spec-file-path)
+  - [`asyncapi config context current`](#asyncapi-config-context-current)
+  - [`asyncapi config context edit CONTEXT-NAME NEW-SPEC-FILE-PATH`](#asyncapi-config-context-edit-context-name-new-spec-file-path)
+  - [`asyncapi config context init [CONTEXT-FILE-PATH]`](#asyncapi-config-context-init-context-file-path)
+  - [`asyncapi config context list`](#asyncapi-config-context-list)
+  - [`asyncapi config context remove CONTEXT-NAME`](#asyncapi-config-context-remove-context-name)
+  - [`asyncapi config context use CONTEXT-NAME`](#asyncapi-config-context-use-context-name)
+  - [`asyncapi config versions`](#asyncapi-config-versions)
+  - [`asyncapi convert [SPEC-FILE]`](#asyncapi-convert-spec-file)
+  - [`asyncapi diff OLD NEW`](#asyncapi-diff-old-new)
+  - [`asyncapi format [SPEC-FILE]`](#asyncapi-format-spec-file)
+  - [`asyncapi generate`](#asyncapi-generate)
+  - [`asyncapi generate fromTemplate ASYNCAPI TEMPLATE`](#asyncapi-generate-fromtemplate-asyncapi-template)
+  - [`asyncapi generate models LANGUAGE FILE`](#asyncapi-generate-models-language-file)
+  - [`asyncapi new`](#asyncapi-new)
+  - [`asyncapi new file`](#asyncapi-new-file)
+  - [`asyncapi new glee`](#asyncapi-new-glee)
+  - [`asyncapi new template`](#asyncapi-new-template)
+  - [`asyncapi optimize [SPEC-FILE]`](#asyncapi-optimize-spec-file)
+  - [`asyncapi pretty SPEC-FILE`](#asyncapi-pretty-spec-file)
+  - [`asyncapi start`](#asyncapi-start)
+  - [`asyncapi start studio [SPEC-FILE]`](#asyncapi-start-studio-spec-file)
+  - [`asyncapi validate [SPEC-FILE]`](#asyncapi-validate-spec-file)
 
 ## `asyncapi bundle`
 
@@ -458,7 +460,8 @@ DESCRIPTION
   Generates whatever you want using templates compatible with AsyncAPI Generator.
 
 EXAMPLES
-  $ asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template --param version=1.0.0 singleFile=true --output ./docs --force-write
+  $ asyncapi generate fromTemplate - start creation of a template in interactive mode
+  $ asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template@3.0.0 --use-new-generator
 ```
 
 _See code: [src/commands/generate/fromTemplate.ts](https://github.com/asyncapi/cli/blob/v2.16.4/src/commands/generate/fromTemplate.ts)_

--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -64,8 +64,8 @@ export default class Template extends Command {
   };
 
   static args = {
-    asyncapi: Args.string({ description: '- Local path, url or context-name pointing to AsyncAPI file', required: true }),
-    template: Args.string({ description: '- Name of the generator template like for example @asyncapi/html-template or https://github.com/asyncapi/html-template', required: true }),
+    asyncapi: Args.string({ description: '- Local path, url or context-name pointing to AsyncAPI file', required: false }),
+    template: Args.string({ description: '- Name of the generator template like for example @asyncapi/html-template or https://github.com/asyncapi/html-template', required: false }),
   };
 
   parser = new Parser();
@@ -73,8 +73,8 @@ export default class Template extends Command {
   async run() {
     const { args, flags } = await this.parse(Template); // NOSONAR
     const interactive = !flags['no-interactive'];
-
-    let { asyncapi, template } = args;
+    let asyncapi = args['asyncapi'] ?? '';
+    let template = args['template'] ?? '';
     let output = flags.output as string;
     const {proxyPort,proxyHost} = flags;
     if (interactive) {


### PR DESCRIPTION
**Description**
Made the 2 args for command `asyncapi generate fromTemplate` not required to make the CLI more user-friendly, aligning it with common interactive CLI patterns.
Users will be able to run `asyncapi generate fromTemplate` without needing to remember or type the required arguments.

![Screenshot 2025-02-19 122607](https://github.com/user-attachments/assets/08bee835-fcdc-4239-91c2-131a56453571)

**Related issue(s)**
Fixes #1660 