### PR TITLE
fix(cli): resolve inaccurate error message in asyncapi optimize command #1626

### DIFF
--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -86,8 +86,8 @@ export default class Optimize extends Command {
     } catch (err) {
       this.error(
         new ValidationError({
-          type: 'invalid-file',
-          filepath: filePath,
+          type: 'parser-error', // Use 'parser-error' instead of 'invalid-file'
+          err: err,            // Pass the actual error so buildError can handle it
         })
       );
     }


### PR DESCRIPTION
fix(cli): resolve inaccurate error message in asyncapi optimize command #1626 



**Description:**

I’ve investigated the issue with the misleading error message, and here’s what I found:

### Problem:

When running the command:

```
asyncapi optimize ./asyncapi-client.yaml
```

Even with a valid file path, an incorrect error message appeared:

```
ValidationError: There is no file or context with name "./asyncapi-client.yaml".
```

After debugging, I found that the issue lies in the following code section:

```typescript
let optimizer: Optimizer;
let report: Report;
try {
  optimizer = new Optimizer(this.specFile.text());
  report = await optimizer.getReport();
} catch (err) {
  this.error(
    new ValidationError({
      type: 'invalid-file',
      filepath: filePath,
    })
  );
}
```

### Root Cause:

The `catch` block throws a `ValidationError` with type `invalid-file`, which causes the misleading message about the file not existing — even when the file is valid but contains parsing issues.

### Fix:

I changed the error type from `invalid-file` to `parser-error`. This way, the `ValidationError` will provide more accurate and detailed parsing error messages instead of falsely indicating a missing file.

```typescript
catch (err) {
  this.error(
    new ValidationError({
      type: 'parser-error',
      err: err,
    })
  );
}
```

With this change, users will see the actual parsing errors, making debugging much easier!

I’ve pushed the fix and raised a PR. Could you please review it? Let me know if you’d like any adjustments.

Thanks! 🚀



