### PR TITLE
fix: update the aysncapi/generator to latest compatible version

### DIFF
--- a/action-template.yml
+++ b/action-template.yml
@@ -15,7 +15,7 @@ inputs:
     default: 'asyncapi.yml'
   template:
     description: 'Template for the generator. Official templates are listed here https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate. You can pass template as npm package, url to git repository, link to tar file or local template.'
-    default: '@asyncapi/markdown-template@0.10.0'
+    default: '@asyncapi/markdown-template@1.6.7'
     required: false
   language:
     description: 'Language of the generated code. This input is required if you want to generate models. List of available languages can be found in https://www.asyncapi.com/docs/tools/cli/usage#asyncapi-generate-models-language-file'

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: 'asyncapi.yml'
   template:
     description: 'Template for the generator. Official templates are listed here https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate. You can pass template as npm package, url to git repository, link to tar file or local template.'
-    default: '@asyncapi/markdown-template@0.10.0'
+    default: '@asyncapi/markdown-template@1.6.7'
     required: false
   language:
     description: 'Language of the generated code. This input is required if you want to generate models. List of available languages can be found in https://www.asyncapi.com/docs/tools/cli/usage#asyncapi-generate-models-language-file'

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -61,7 +61,7 @@ Path to the AsyncAPI document that you want to process.
 
 Template for the generator. Official templates are listed here https://github.com/asyncapi/generator#list-of-official-generator-templates. You can pass template as npm package, url to git repository, link to tar file or local template.
 
-**Default** points to `@asyncapi/markdown-template@0.10.0` template.
+**Default** points to `@asyncapi/markdown-template@1.6.7` template.
 
 > [!TIP]
 > We recommend to always specify the version of the template to not encounter any issues with the action in case of release of the template that is not compatible with given version of the generator.
@@ -229,7 +229,7 @@ Use following commands to run and test github action locally:
 2. Execute docker image with proper arguments
 
   ```bash
-    docker run -e GITHUB_WORKSPACE="" --workdir /action  -v "/home/{user}/path/to/repo":"/action" asyncapi/github-action-for-cli  "" "generate" "github-action/test/asyncapi.yml" "@asyncapi/markdown-template@0.10.0" "" "output" "" ""
+    docker run -e GITHUB_WORKSPACE="" --workdir /action  -v "/home/{user}/path/to/repo":"/action" asyncapi/github-action-for-cli  "" "generate" "github-action/test/asyncapi.yml" "@asyncapi/markdown-template@1.6.7" "" "output" "" ""
   ```
 
 Make sure to change the path of the repo and user in the command.

--- a/github-action/Makefile
+++ b/github-action/Makefile
@@ -1,7 +1,7 @@
 DEFAULT_VERSION = 'latest'
 DEFAULT_COMMAND = 'generate'
 TEST_FILEPATH = 'test/asyncapi.yml'
-DEFAULT_TEMPLATE = '@asyncapi/markdown-template@0.10.0'
+DEFAULT_TEMPLATE = '@asyncapi/markdown-template@1.6.7'
 DEFAULT_LANGUAGE = ''
 DEFAULT_OUTPUT = 'output'
 DEFAULT_PARAMETERS = ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@asyncapi/bundler": "^0.6.4",
         "@asyncapi/converter": "^1.6.2",
         "@asyncapi/diff": "^0.5.0",
-        "@asyncapi/generator": "^2.6.0",
+        "@asyncapi/generator": "^2.0.0",
         "@asyncapi/modelina-cli": "^4.0.0-next.48",
         "@asyncapi/openapi-schema-parser": "^3.0.24",
         "@asyncapi/optimizer": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@asyncapi/bundler": "^0.6.4",
         "@asyncapi/converter": "^1.6.2",
         "@asyncapi/diff": "^0.5.0",
-        "@asyncapi/generator": "^1.17.25",
+        "@asyncapi/generator": "^2.6.0",
         "@asyncapi/modelina-cli": "^4.0.0-next.48",
         "@asyncapi/openapi-schema-parser": "^3.0.24",
         "@asyncapi/optimizer": "^1.0.4",
@@ -273,15 +273,18 @@
       }
     },
     "node_modules/@asyncapi/generator": {
-      "version": "1.17.25",
-      "resolved": "https://registry.npmjs.org/@asyncapi/generator/-/generator-1.17.25.tgz",
-      "integrity": "sha512-Wz8qFkHl13jYs9QeDEf/xScod4ukjQihFC9La4zsYA73sTc29RpIK0URvXJr/1rkTErU+QaNDbnbRHhlnqlm4w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator/-/generator-2.6.0.tgz",
+      "integrity": "sha512-ATGyvShQ0JHpx91N0FbwHtbxOPOtDgl6RUsqQVJ4MHfLZ1RjbsGnn7nN1LYGusbrX2oIZVmJBWcZyJ74JLuJZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-react-sdk": "^1.0.18",
+        "@asyncapi/generator-hooks": "*",
+        "@asyncapi/generator-react-sdk": "^1.1.2",
+        "@asyncapi/multi-parser": "^2.1.1",
+        "@asyncapi/nunjucks-filters": "*",
         "@asyncapi/parser": "^3.0.14",
         "@npmcli/arborist": "5.6.3",
-        "@smoya/multi-parser": "^5.0.0",
+        "@npmcli/config": "^8.0.2",
         "ajv": "^8.12.0",
         "chokidar": "^3.4.0",
         "commander": "^6.1.0",
@@ -295,11 +298,11 @@
         "minimatch": "^3.0.4",
         "node-fetch": "^2.6.0",
         "nunjucks": "^3.2.0",
+        "requireg": "^0.2.2",
         "resolve-from": "^5.0.0",
         "resolve-pkg": "^2.0.0",
         "semver": "^7.3.2",
         "simple-git": "^3.3.0",
-        "source-map-support": "^0.5.19",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.3"
       },
@@ -308,8 +311,18 @@
         "asyncapi-generator": "cli.js"
       },
       "engines": {
-        "node": ">12.16",
-        "npm": ">6.13.7"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.0"
+      }
+    },
+    "node_modules/@asyncapi/generator-hooks": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator-hooks/-/generator-hooks-0.1.0.tgz",
+      "integrity": "sha512-cTfwiXNrNE4Z5ZkbLyX4jCAnJEQgTXpPRhSzTpt08R3Md+2tO8CMQWo4B4C8fSSy3M4aBWePJ4bbILOEqduvUg==",
+      "deprecated": "Hooks are now part of generator repository and also out of the box integrated with the generator, so no need to set it as dependency any more: https://github.com/asyncapi/generator/releases/tag/%40asyncapi%2Fgenerator%402.5.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fs.extra": "^1.3.2"
       }
     },
     "node_modules/@asyncapi/generator-react-sdk": {
@@ -3663,6 +3676,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@asyncapi/bundler": "^0.6.4",
     "@asyncapi/converter": "^1.6.2",
     "@asyncapi/diff": "^0.5.0",
-    "@asyncapi/generator": "^2.6.0",
+    "@asyncapi/generator": "^2.0.0",
     "@asyncapi/modelina-cli": "^4.0.0-next.48",
     "@asyncapi/openapi-schema-parser": "^3.0.24",
     "@asyncapi/optimizer": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@asyncapi/bundler": "^0.6.4",
     "@asyncapi/converter": "^1.6.2",
     "@asyncapi/diff": "^0.5.0",
-    "@asyncapi/generator": "^1.17.25",
+    "@asyncapi/generator": "^2.6.0",
     "@asyncapi/modelina-cli": "^4.0.0-next.48",
     "@asyncapi/openapi-schema-parser": "^3.0.24",
     "@asyncapi/optimizer": "^1.0.4",


### PR DESCRIPTION
**Title** : Update the aysncapi/generator to latest stable version #1699 

**Description** : update the asynccpi/generate package to latest stable version which will not support @asyncapi/html-template 


**Before** : 
![Screenshot from 2025-03-08 10-10-57](https://github.com/user-attachments/assets/a67a719e-44f7-4b49-ad04-002fabfeab76)

**After** : 
![image](https://github.com/user-attachments/assets/abc89d3f-ed27-41c2-9f13-88c13f71ab06)

