### PR TITLE
chore: json file supported in asyncapi new file command

### DIFF
--- a/.changeset/blue-seas-destroy.md
+++ b/.changeset/blue-seas-destroy.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+[Fix]: Json file supported in asyncapi new file command

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@
 /yarn.lock
 /assets/examples/**
 !assets/examples/default-example.yaml
-!assets/examples/tutorial.yml
+!assets/examples/tutorial.yml'
+!assets/examples/default-example.json
 node_modules
 /test/integration/generate/models/
 test.asyncapi-cli

--- a/assets/examples/default-example.json
+++ b/assets/examples/default-example.json
@@ -1,0 +1,51 @@
+{
+    "asyncapi": "3.0.0",
+    "info": {
+      "title": "Account Service",
+      "version": "1.0.0",
+      "description": "This service is in charge of processing user signups"
+    },
+    "channels": {
+      "userSignedUp": {
+        "address": "user/signedup",
+        "messages": {
+          "UserSignedUp": {
+            "$ref": "#/components/messages/UserSignedUp"
+          }
+        }
+      }
+    },
+    "operations": {
+      "onUserSignUp": {
+        "action": "receive",
+        "channel": {
+          "$ref": "#/channels/userSignedUp"
+        },
+        "messages": [
+          {
+            "$ref": "#/channels/userSignedUp/messages/UserSignedUp"
+          }
+        ]
+      }
+    },
+    "components": {
+      "messages": {
+        "UserSignedUp": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "displayName": {
+                "type": "string",
+                "description": "Name of the user"
+              },
+              "email": {
+                "type": "string",
+                "format": "email",
+                "description": "Email of the user"
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/src/commands/new/file.ts
+++ b/src/commands/new/file.ts
@@ -9,7 +9,8 @@ import { fileFlags } from '../../core/flags/new/file.flags';
 
 const { writeFile, readFile } = fPromises;
 const DEFAULT_ASYNCAPI_FILE_NAME = 'asyncapi.yaml';
-const DEFAULT_ASYNCAPI_TEMPLATE = 'default-example.yaml';
+const DEFAULT_ASYNCAPI_YAML_TEMPLATE = 'default-example.yaml';
+const DEFAULT_ASYNCAPI_JSON_TEMPLATE = 'default-example.json';
 
 interface IExample{
   name: string,
@@ -49,7 +50,14 @@ export default class NewFile extends Command {
     }
 
     const fileName = flags['file-name'] || DEFAULT_ASYNCAPI_FILE_NAME;
-    const template = flags['example'] || DEFAULT_ASYNCAPI_TEMPLATE;
+    // Determine template based on file extension
+    let default_template;
+    if (fileName.endsWith('.json')) {
+      default_template = DEFAULT_ASYNCAPI_JSON_TEMPLATE;
+    } else {
+      default_template = DEFAULT_ASYNCAPI_YAML_TEMPLATE;
+    }
+    const template = flags['example'] || default_template;
 
     await this.createAsyncapiFile(fileName, template);
 
@@ -124,7 +132,14 @@ export default class NewFile extends Command {
     }
 
     fileName = fileName || DEFAULT_ASYNCAPI_FILE_NAME;
-    selectedTemplate = selectedTemplate || DEFAULT_ASYNCAPI_TEMPLATE;
+    // Determine template based on file extension
+    let default_template;
+    if (fileName.endsWith('.json')) {
+      default_template = DEFAULT_ASYNCAPI_JSON_TEMPLATE;
+    } else {
+      default_template = DEFAULT_ASYNCAPI_YAML_TEMPLATE;
+    }
+    selectedTemplate = selectedTemplate || default_template;
 
     await this.createAsyncapiFile(fileName, selectedTemplate);
     fileName = fileName.includes('.') ? fileName : `${fileName}.yaml`;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Added `default-example.json` file, which will be displayed as the default JSON example.
- Used AsyncAPI Studio to convert `default-example.yaml` into JSON format.
- Ensured the JSON file accurately reflects the structure and content of the original YAML file.

**Related issue(s)**

Resolves #1710
