### PR TITLE
Update async-cli package to use ES modules

### DIFF
--- a/assets/create-glee-app/templates/default/tsconfig.json
+++ b/assets/create-glee-app/templates/default/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es6",
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "module": "commonjs",
+    "module": "ESNext",
     "skipLibCheck": true
   }
 }

--- a/assets/create-glee-app/templates/tutorial/tsconfig.json
+++ b/assets/create-glee-app/templates/tutorial/tsconfig.json
@@ -4,6 +4,6 @@
     "target": "es6",
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "module": "commonjs"
+    "module": "ESNext"
   }
 }

--- a/package.json
+++ b/package.json
@@ -172,5 +172,6 @@
     "action:docker:build": "docker build -f github-action/Dockerfile -t asyncapi/github-action-for-cli:latest .",
     "action:test": "cd github-action && make test"
   },
-  "types": "lib/index.d.ts"
+  "types": "lib/index.d.ts",
+  "type": "module"
 }

--- a/scripts/fetch-asyncapi-example.js
+++ b/scripts/fetch-asyncapi-example.js
@@ -1,15 +1,12 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-
-const fs = require('fs');
-const unzipper = require('unzipper');
-const path = require('path');
-
-const { Parser } = require('@asyncapi/parser/cjs');
-const { AvroSchemaParser } = require('@asyncapi/avro-schema-parser');
-const { OpenAPISchemaParser } = require('@asyncapi/openapi-schema-parser');
-const { RamlDTSchemaParser } = require('@asyncapi/raml-dt-schema-parser');
-const { pipeline } = require('stream');
-const { promisify } = require('util');
+import fs from 'fs';
+import unzipper from 'unzipper';
+import path from 'path';
+import { Parser } from '@asyncapi/parser';
+import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
+import { OpenAPISchemaParser } from '@asyncapi/openapi-schema-parser';
+import { RamlDTSchemaParser } from '@asyncapi/raml-dt-schema-parser';
+import { pipeline } from 'stream';
+import { promisify } from 'util';
 
 const streamPipeline = promisify(pipeline);
 

--- a/scripts/releasePackagesRename.js
+++ b/scripts/releasePackagesRename.js
@@ -1,10 +1,9 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
+import { rename, access, mkdir } from 'fs/promises';
+import packageJson from '../package.json';
+import path from 'path';
+import simpleGit from 'simple-git';
 
-const { rename, access, mkdir } = require('fs').promises;
-const packageJson = require('../package.json');
-const path = require('path');
-const simpleGit = require('simple-git');
-const git = simpleGit({baseDir: process.cwd()});
+const git = simpleGit({ baseDir: process.cwd() });
 
 async function fileExists(checkPath) {
   try {
@@ -28,7 +27,7 @@ async function createDirectory(directoryPath) {
   }
 }
 
-async function renameDeb({version, name, sha}) {
+async function renameDeb({ version, name, sha }) {
   const dist = 'dist/deb';
 
   // deb package naming convention: https://github.com/oclif/oclif/blob/fb5da961f925fa0eba5c5b05c8cee0c9bd156c00/src/upload-util.ts#L51
@@ -37,7 +36,7 @@ async function renameDeb({version, name, sha}) {
   await checkAndRenameFile(generatedPath, newPath);
 }
 
-async function renameTar({version, name, sha}) {
+async function renameTar({ version, name, sha }) {
   const dist = 'dist';
 
   const generatedPath = path.resolve(dist, `${name}-v${version}-${sha}-linux-x64.tar.gz`);
@@ -49,7 +48,7 @@ async function renameTar({version, name, sha}) {
   await checkAndRenameFile(generatedPath, newPath);
 }
 
-async function renameWindows({version, name, sha, arch}) {
+async function renameWindows({ version, name, sha, arch }) {
   const dist = 'dist/win32';
 
   const generatedPath = path.resolve(dist, `${name}-v${version}-${sha}-${arch}.exe`);
@@ -57,7 +56,7 @@ async function renameWindows({version, name, sha, arch}) {
   await checkAndRenameFile(generatedPath, newPath);
 }
 
-async function renamePkg({version, name, sha, arch}) {
+async function renamePkg({ version, name, sha, arch }) {
   const dist = 'dist/macos';
 
   const generatedPath = path.resolve(dist, `${name}-v${version}-${sha}-${arch}.pkg`);
@@ -69,12 +68,12 @@ async function renamePackages() {
   const version = packageJson.version;
   const name = 'asyncapi';
   const sha = await git.revparse(['--short', 'HEAD']);
-  await renameDeb({version: version.split('-')[0], name, sha});
-  await renamePkg({version, name, sha, arch: 'x64'});
-  await renamePkg({version, name, sha, arch: 'arm64'});
-  await renameWindows({version, name, sha, arch: 'x64'});
-  await renameWindows({version, name, sha, arch: 'x86'});
-  await renameTar({version, name, sha});
+  await renameDeb({ version: version.split('-')[0], name, sha });
+  await renamePkg({ version, name, sha, arch: 'x64' });
+  await renamePkg({ version, name, sha, arch: 'arm64' });
+  await renameWindows({ version, name, sha, arch: 'x64' });
+  await renameWindows({ version, name, sha, arch: 'x86' });
+  await renameTar({ version, name, sha });
 }
 
 renamePackages();

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -1,12 +1,12 @@
 import Command from '../core/base';
 import bundle from '@asyncapi/bundler';
-import { promises } from 'fs';
+import { promises as fsPromises } from 'fs';
 import path from 'path';
 import { Specification } from '../core/models/SpecificationFile';
 import { Document } from '@asyncapi/bundler/lib/document';
 import { bundleFlags } from '../core/flags/bundle.flags';
 
-const { writeFile } = promises;
+const { writeFile } = fsPromises;
 
 export default class Bundle extends Command {
   static readonly description = 'Bundle one or multiple AsyncAPI Documents and their references together.';

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { promises as fPromises } from 'fs';
 import { Args } from '@oclif/core';
 import Command from '../core/base';
@@ -9,7 +8,6 @@ import { convert, convertOpenAPI, convertPostman } from '@asyncapi/converter';
 import type { AsyncAPIConvertVersion, OpenAPIConvertVersion } from '@asyncapi/converter';
 import { cyan, green } from 'picocolors';
 import { proxyFlags } from '../core/flags/proxy.flags';
-// @ts-ignore
 import specs from '@asyncapi/specs';
 import { convertFlags } from '../core/flags/convert.flags';
 

--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -1,7 +1,5 @@
 import { Args } from '@oclif/core';
 import Command from '../../core/base';
-// eslint-disable-next-line
-// @ts-ignore
 import AsyncAPIGenerator from '@asyncapi/generator';
 import AsyncAPINewGenerator from 'generator-v2';
 import path from 'path';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { run } from '@oclif/core';
+import { run } from '@oclif/core';
 
 /**
  * For NodeJS < 15, unhandled rejections are treated as warnings.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./lib",
     "baseUrl": "./src",
     "target": "es6",
-    "module": "commonjs",
+    "module": "ESNext",
     "lib": [
       "esnext",
     ],


### PR DESCRIPTION
Fixes #1698

Update `async-cli` package to use ES modules instead of CommonJS.

* **Update `tsconfig.json` files:**
  - Change `module` to `ESNext` in `tsconfig.json`, `assets/create-glee-app/templates/default/tsconfig.json`, and `assets/create-glee-app/templates/tutorial/tsconfig.json`.
  - Update `moduleResolution` to `node` in the same files.

* **Update `package.json`:**
  - Add `"type": "module"`.

* **Update import/export syntax:**
  - Modify import statements in `src/commands/bundle.ts`, `src/commands/convert.ts`, `src/commands/generate/fromTemplate.ts`, `scripts/fetch-asyncapi-example.js`, `scripts/releasePackagesRename.js`, and `src/index.ts` to use ES module syntax.

