### PR TITLE
fix: studio command not working

### DIFF
--- a/.changeset/free-dodos-matter.md
+++ b/.changeset/free-dodos-matter.md
@@ -1,0 +1,5 @@
+---
+'@asyncapi/cli': patch
+---
+
+Fix studio not opening in CLI studio command

--- a/.changeset/stupid-beans-kick.md
+++ b/.changeset/stupid-beans-kick.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: studio command not working

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/cli",
-  "version": "2.16.7",
+  "version": "2.16.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/cli",
-      "version": "2.16.7",
+      "version": "2.16.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.23",
@@ -20,7 +20,7 @@
         "@asyncapi/parser": "^3.3.0",
         "@asyncapi/protobuf-schema-parser": "^3.5.1",
         "@asyncapi/raml-dt-schema-parser": "^4.0.24",
-        "@asyncapi/studio": "^0.23.0",
+        "@asyncapi/studio": "^0.23.1",
         "@clack/prompts": "^0.7.0",
         "@oclif/core": "^4.2.9",
         "@smoya/asyncapi-adoption-metrics": "^2.4.9",
@@ -694,7 +694,9 @@
       }
     },
     "node_modules/@asyncapi/studio": {
-      "version": "0.23.0",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/studio/-/studio-0.23.1.tgz",
+      "integrity": "sha512-63qhUg8NBZt7lLnc2SVx5hJbP/wylyDaeil70Dq9tfK0Q4tgwyUumT71vOz9RE8SkKsDKeEFZdIdpHkyCy0MGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.19",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@asyncapi/parser": "^3.3.0",
     "@asyncapi/protobuf-schema-parser": "^3.5.1",
     "@asyncapi/raml-dt-schema-parser": "^4.0.24",
-    "@asyncapi/studio": "^0.23.0",
+    "@asyncapi/studio": "^0.23.1",
     "@clack/prompts": "^0.7.0",
     "@oclif/core": "^4.2.9",
     "@smoya/asyncapi-adoption-metrics": "^2.4.9",


### PR DESCRIPTION
**Description**

- Studio was not working as there was no `next.config.js` packaged in the build. Now it has been added leading to requirement of a manual bump.

**Related issue(s)**
Fixes #1718 