### PR TITLE
fix: wrong error message in -h command #1725

### DIFF
--- a/.changeset/forty-apples-fix.md
+++ b/.changeset/forty-apples-fix.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: Wrong Error message in -h command #1725

--- a/src/core/hooks/command_not_found/myhook.ts
+++ b/src/core/hooks/command_not_found/myhook.ts
@@ -23,7 +23,7 @@ const hook: Hook.CommandNotFound = async function (opts) {
 
   // now we we return if the command id are not there.
 
-  let binHelp = `${opts.config.bin} help`;
+  let binHelp = `${opts.config.bin} --help`;
 
   const idSplit = opts.id.split(':');
   if (opts.config.findTopic(idSplit[0])) {


### PR DESCRIPTION
**Title** : Wrong Error message in -h command #1725 

**Description** : This pr will fix the issue of wrong error message which was shown after entering a invalid command 

**Before** : 
![image](https://github.com/user-attachments/assets/9a6cf70f-c8a8-42a3-85ea-572dca319da1)


**After** : 

![image](https://github.com/user-attachments/assets/5ad63954-48ef-4aef-bca0-fe84b9c34d47)

 