### PR TITLE
feat: added interactive steps to using asyncapi start studio command 

### DIFF
--- a/src/commands/start/studio.ts
+++ b/src/commands/start/studio.ts
@@ -1,8 +1,10 @@
 import Command from '../../core/base';
+import fs from 'fs';
 import { start as startStudio } from '../../core/models/Studio';
 import { load } from '../../core/models/SpecificationFile';
 import { studioFlags } from '../../core/flags/start/studio.flags';
 import { Args } from '@oclif/core';
+import { isCancel, confirm, text } from '@clack/prompts';
 
 export default class StartStudio extends Command {
   static description = 'starts a new local instance of Studio';
@@ -15,31 +17,70 @@ export default class StartStudio extends Command {
 
   async run() {
     const { args, flags } = await this.parse(StartStudio);
+    const cancellationMessage = 'Operation cancelled';
 
     if (flags.file) {
       this.warn('The file flag has been removed and is being replaced by the argument spec-file. Please pass the filename directly like `asyncapi start studio asyncapi.yml`');
     }
-
-    let filePath = args['spec-file'] ?? flags.file;
-
-    const port = flags.port;
-    if (!filePath) {
-      try {
-        filePath = ((await load()).getFilePath());
-        this.log(`Loaded specification from: ${filePath}`);
-      } catch (error) {
-        filePath = '';
-        this.error('No file specified.');
-      }
-    }
+    const filePath = await this.getSpecFile(args['spec-file'] ?? flags.file, cancellationMessage);
     try {
-      this.specFile = await load(filePath);
+      this.specFile = await load(filePath as string | undefined);
     } catch (error) {
       if (filePath) {
         this.error(error as Error);
       }
     }
+    
+    const port = await this.getPort(flags.port, cancellationMessage);  
     this.metricsMetadata.port = port;
     startStudio(filePath as string, port);
+  }
+
+  private async getSpecFile(filePath: string | undefined, cancellationMessage: string) {
+    if (filePath) return filePath;
+    
+    const response = await confirm({ message: 'Do you want to start AsyncAPI Studio with any reference? [y/n]' });
+    if (isCancel(response)) {
+      this.error(cancellationMessage, { exit: 1 });
+    }
+    if (!response) {
+      try {
+        const filePath = (await load()).getFilePath();
+        this.log(`Loaded specification from: ${filePath}`);
+        return filePath;
+      } catch (error) {
+        this.error('No file specified.');
+      }
+    }
+    const asyncapi = await text({
+      message: 'Please provide the path to the AsyncAPI document',
+      placeholder: 'asyncapi.yaml',
+      defaultValue: 'asyncapi.yaml',
+      validate: (value) => {
+        if (!value) return 'The path to the AsyncAPI document is required';
+        if (!fs.existsSync(value)) return 'The file does not exist';
+      }
+    });
+    
+    if (isCancel(asyncapi)) {
+      this.error(cancellationMessage, { exit: 1 });
+    }
+    return asyncapi;
+  }
+  
+  private async getPort(port: number | undefined, cancellationMessage: string) {
+    if (port) return port;
+    
+    const portInput = await text({
+      message: 'Which port do you want to start AsyncAPI Studio on',
+      placeholder: '3210',
+      defaultValue: '3210',
+      validate: (value) => (!value ? 'The port number is required' : undefined),
+    });
+
+    if (isCancel(portInput)) {
+      this.error(cancellationMessage, { exit: 1 });
+    }
+    return Number.parseInt(portInput);
   }
 }

--- a/src/commands/start/studio.ts
+++ b/src/commands/start/studio.ts
@@ -37,7 +37,7 @@ export default class StartStudio extends Command {
   }
 
   private async getSpecFile(filePath: string | undefined, cancellationMessage: string) {
-    if (filePath) return filePath;
+    if (filePath) { return filePath; }
     
     const response = await confirm({ message: 'Do you want to start AsyncAPI Studio with any reference? [y/n]' });
     if (isCancel(response)) {
@@ -57,8 +57,8 @@ export default class StartStudio extends Command {
       placeholder: 'asyncapi.yaml',
       defaultValue: 'asyncapi.yaml',
       validate: (value) => {
-        if (!value) return 'The path to the AsyncAPI document is required';
-        if (!fs.existsSync(value)) return 'The file does not exist';
+        if (!value) {return 'The path to the AsyncAPI document is required';}
+        if (!fs.existsSync(value)) {return 'The file does not exist';}
       }
     });
     
@@ -69,7 +69,7 @@ export default class StartStudio extends Command {
   }
   
   private async getPort(port: number | undefined, cancellationMessage: string) {
-    if (port) return port;
+    if (port) { return port; }
     
     const portInput = await text({
       message: 'Which port do you want to start AsyncAPI Studio on',
@@ -81,6 +81,6 @@ export default class StartStudio extends Command {
     if (isCancel(portInput)) {
       this.error(cancellationMessage, { exit: 1 });
     }
-    return Number.parseInt(portInput);
+    return Number.parseInt(portInput, 10);
   }
 }


### PR DESCRIPTION
Fixes #1727 
Added Interactive steps for `asyncapi start studio` command for specifying 

- To start with a reference file
- Path or reference file
- Port value

![2025-03-20_11-53](https://github.com/user-attachments/assets/49a63134-fd27-4842-b8ec-87fd20f7008c)
