### PR TITLE
feat: made start studio command interactive

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -746,15 +746,16 @@ starts a new local instance of Studio
 
 ```
 USAGE
-  $ asyncapi start studio [SPEC-FILE] [-h] [-f <value>] [-p <value>]
+  $ asyncapi start studio [SPEC-FILE] [-h] [-f <value>] [-p <value>] [--no-interactive]
 
 ARGUMENTS
   SPEC-FILE  spec path, url, or context-name
 
 FLAGS
-  -f, --file=<value>  path to the AsyncAPI file to link with Studio
-  -h, --help          Show CLI help.
-  -p, --port=<value>  port in which to start Studio
+  -f, --file=<value>   path to the AsyncAPI file to link with Studio
+  -h, --help           Show CLI help.
+  -p, --port=<value>   port in which to start Studio
+      --no-interactive disables prompts for this command which asks for file path if not passed via the arguments.
 
 DESCRIPTION
   starts a new local instance of Studio

--- a/src/commands/start/studio.ts
+++ b/src/commands/start/studio.ts
@@ -3,6 +3,7 @@ import { start as startStudio } from '../../core/models/Studio';
 import { load } from '../../core/models/SpecificationFile';
 import { studioFlags } from '../../core/flags/start/studio.flags';
 import { Args } from '@oclif/core';
+import { isCancel, text, cancel } from '@clack/prompts';
 
 export default class StartStudio extends Command {
   static description = 'starts a new local instance of Studio';
@@ -16,13 +17,22 @@ export default class StartStudio extends Command {
   async run() {
     const { args, flags } = await this.parse(StartStudio);
 
+    let filePath = args['spec-file'] ?? flags.file;
+
+    let port = flags.port;
+
     if (flags.file) {
       this.warn('The file flag has been removed and is being replaced by the argument spec-file. Please pass the filename directly like `asyncapi start studio asyncapi.yml`');
     }
 
-    let filePath = args['spec-file'] ?? flags.file;
+    const isInteractive = !flags['no-interactive'];
 
-    const port = flags.port;
+    if (isInteractive && !filePath) {
+      const parsedArgs = await this.parseArgs({ filePath }, port?.toString());
+      filePath = parsedArgs.filePath;
+      port = parseInt(parsedArgs.port,10);
+    }
+
     if (!filePath) {
       try {
         filePath = ((await load()).getFilePath());
@@ -41,5 +51,43 @@ export default class StartStudio extends Command {
     }
     this.metricsMetadata.port = port;
     startStudio(filePath as string, port);
+  }
+
+  private async parseArgs(args:Record<string,any>,port?:string) {
+    const operationCancelled = 'Operation cancelled by the user.';
+    let askForPort = false;
+    let {filePath} = args;
+    if (!filePath) {
+      filePath = await text({
+        message: 'Enter the path to the AsyncAPI document',
+        defaultValue: 'asyncapi.yaml',
+        placeholder: 'asyncapi.yaml',
+        validate: (value) => {
+          if (!value) {return 'The path to the AsyncAPI document is required';}
+        },
+      });
+      askForPort = true;
+    }
+
+    if (isCancel(filePath)) {
+      cancel(operationCancelled);
+      this.exit();
+    }
+
+    if (!port && askForPort) {
+      port = await text({
+        message: 'Enter the port in which to start Studio',
+        defaultValue: '3210',
+        placeholder: '3210',
+        validate: (value) => (!value ? 'The port number is required' : undefined),
+      }) as string;
+    }
+
+    if (isCancel(port)) {
+      cancel(operationCancelled);
+      this.exit();
+    }
+  
+    return { filePath, port: port ?? '3210' };
   }
 }

--- a/src/core/flags/start/studio.flags.ts
+++ b/src/core/flags/start/studio.flags.ts
@@ -6,7 +6,7 @@ export const studioFlags = () => {
     file: Flags.string({ char: 'f', description: 'path to the AsyncAPI file to link with Studio', deprecated: true }),
     port: Flags.integer({ char: 'p', description: 'port in which to start Studio' }),
     'no-interactive': Flags.boolean({
-      description: 'disables prompts for this command which asks for file path even if not passed via the arguments.',
+      description: 'disables prompts for this command which asks for file path if not passed via the arguments.',
       required: false,
       default: false,
     }),

--- a/src/core/flags/start/studio.flags.ts
+++ b/src/core/flags/start/studio.flags.ts
@@ -5,5 +5,10 @@ export const studioFlags = () => {
     help: Flags.help({ char: 'h' }),
     file: Flags.string({ char: 'f', description: 'path to the AsyncAPI file to link with Studio', deprecated: true }),
     port: Flags.integer({ char: 'p', description: 'port in which to start Studio' }),
+    'no-interactive': Flags.boolean({
+      description: 'disables prompts for this command which asks for file path even if not passed via the arguments.',
+      required: false,
+      default: false,
+    }),
   };
 };


### PR DESCRIPTION
**Description**

This PR introduces the changes to make the `asyncapi start studio` command interactive like rest of the commands. A `--no-interactive` flag is added which like rest of the commands can be used to disable the interactive mode. Making command interactive this ways makes it consistent with other commands in CLI instead of the suggested `Do you need to start the studio from any reference [ Y/ N ]` prompt in the issue.

Below are the screenshots for references.

`no file is passed in the arguments` here prompt is asked

![image](https://github.com/user-attachments/assets/2598d62b-205f-4c4c-931d-b9de7d1c9b24)

`a file is passed in the arguments` no prompt is there

![image](https://github.com/user-attachments/assets/529d1c8e-170f-4eb0-ab7e-569285a01ed4)

`wrong file is passed in the prompt`

![image](https://github.com/user-attachments/assets/807ffb05-26d2-4bec-b264-8a487da03b92)

`no file is passed in argument but also  --no-interactive flag is used`

![image](https://github.com/user-attachments/assets/7c84572f-ae1a-4be4-9943-b722e94b1a67)

output for `start studio -h` command

![image](https://github.com/user-attachments/assets/882183ef-6254-4770-9d86-b511df340068)

The docs are also updated to reflect the changes.

@AayushSaini101 Please review.

Thanks.
 

**Related issue(s)**
Resolves #1727 