### PR TITLE
feat: remove --renderer flag from asyncapi new template command

### DIFF
--- a/.changeset/breezy-pandas-arrive.md
+++ b/.changeset/breezy-pandas-arrive.md
@@ -1,5 +1,5 @@
 ---
-"@asyncapi/cli": patch
+"@asyncapi/cli": minor
 ---
 
-feat: remove --renderer flag from asyncapi new template command
+Remove `--renderer` flag and make `React` as the de-facto renderer, deprecating `Nunjucks`

--- a/.changeset/breezy-pandas-arrive.md
+++ b/.changeset/breezy-pandas-arrive.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+feat: remove --renderer flag from asyncapi new template command

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -635,24 +635,22 @@ _See code: [src/commands/new/glee.ts](https://github.com/asyncapi/cli/blob/v2.16
 
 ## `asyncapi new template`
 
-Creates a new template
+Creates a new template using React render engine
 
 ```
 USAGE
-  $ asyncapi new template [-h] [-n <value>] [-t <value>] [-f <value>] [--force-write] [-r <value>]
+  $ asyncapi new template [-h] [-n <value>] [-t <value>] [-f <value>] [--force-write]
 
 FLAGS
   -f, --file=<value>      The path to the AsyncAPI file for generating a template.
   -h, --help              Show CLI help.
   -n, --name=<value>      [default: project] Name of the Project
-  -r, --renderer=<value>  [default: react] Creating a template for particular engine, Its value can be either react or
-                          nunjucks.
   -t, --template=<value>  [default: default] Name of the Template
       --force-write       Force writing of the generated files to given directory even if it is a git repo with unstaged
                           files or not empty dir (defaults to false)
 
 DESCRIPTION
-  Creates a new template
+  Creates a new template using React render engine
 ```
 
 _See code: [src/commands/new/template.ts](https://github.com/asyncapi/cli/blob/v2.16.4/src/commands/new/template.ts)_

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asyncapi/cli",
-  "version": "2.16.8",
+  "version": "2.16.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/cli",
-      "version": "2.16.8",
+      "version": "2.16.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.23",

--- a/src/commands/new/template.ts
+++ b/src/commands/new/template.ts
@@ -40,15 +40,10 @@ export default class template extends Command {
     const {
       name: projectName,
       template: templateName,
-      renderer: rendererName
     } = flags;
 
     const PROJECT_DIRECTORY = join(process.cwd(), projectName);
-
-    if (rendererName!=='nunjucks' && rendererName!=='react') {
-      this.error('Invalid flag check the flag name of renderer');
-    }
-
+    
     const templateDirectory = resolve(
       __dirname,
       '../../../assets/create-template/templates/',
@@ -81,7 +76,7 @@ export default class template extends Command {
       }
 
       try {
-        await copyAndModify(templateDirectory, PROJECT_DIRECTORY,rendererName, projectName);
+        await copyAndModify(templateDirectory, PROJECT_DIRECTORY, projectName);
         this.log(successMessage(projectName));
       } catch (err) {
         this.error(
@@ -94,7 +89,7 @@ export default class template extends Command {
   }
 }
 
-async function copyAndModify(templateDirectory:string, PROJECT_DIRECTORY:string, rendererName:string, projectName:string) {
+async function copyAndModify(templateDirectory:string, PROJECT_DIRECTORY:string, projectName:string) {
   const packageJsonPath = path.join(templateDirectory, 'package.json');
   try {
     await fs.copy(templateDirectory, PROJECT_DIRECTORY, {
@@ -104,7 +99,7 @@ async function copyAndModify(templateDirectory:string, PROJECT_DIRECTORY:string,
     });
     const packageData = await jsonfile.readFile(packageJsonPath);
     if ((packageData.generator && 'renderer' in packageData.generator)) {
-      packageData.generator.renderer = rendererName;
+      packageData.generator.renderer = 'react';
     }
     if (packageData.name) {
       packageData.name = projectName;

--- a/src/core/flags/new/template.flags.ts
+++ b/src/core/flags/new/template.flags.ts
@@ -23,10 +23,5 @@ export const templateFlags = () => {
       description:
         'Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir (defaults to false)',
     }),
-    renderer: Flags.string({
-      char: 'r',
-      default: 'react',
-      description: 'Creating a template for particular engine, Its value can be either react or nunjucks.'
-    })
   };
 };


### PR DESCRIPTION
**Description**
Remove --renderer flag from asyncapi new template command because only React engine is allowed nunjucks is deprecated.

Below is screenshot of working - 

![image](https://github.com/user-attachments/assets/11ed73f7-91c3-4fb1-afe3-ebdd6ca48a72)


**Related issue(s)**
Fixes #1738