### PR TITLE
feat: new command `asyncapi start preview` implemented.

### DIFF
--- a/.changeset/blue-monkeys-call.md
+++ b/.changeset/blue-monkeys-call.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": minor
+---
+
+feat: new command `asyncapi start preview` has been added

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,6 +66,7 @@ USAGE
   - [`asyncapi pretty SPEC-FILE`](#asyncapi-pretty-spec-file)
   - [`asyncapi start`](#asyncapi-start)
   - [`asyncapi start studio [SPEC-FILE]`](#asyncapi-start-studio-spec-file)
+  - [`asyncapi start preview [SPEC-FILE]`](#asyncapi-start-preview-spec-file)
   - [`asyncapi validate [SPEC-FILE]`](#asyncapi-validate-spec-file)
 
 ## `asyncapi bundle`
@@ -759,6 +760,32 @@ DESCRIPTION
 ```
 
 _See code: [src/commands/start/studio.ts](https://github.com/asyncapi/cli/blob/v2.16.4/src/commands/start/studio.ts)_
+
+## `asyncapi start preview [SPEC-FILE]`
+
+starts a new local instance of Studio in the minimal state bundling all the refs of the schema file and with no editing allowed.
+
+```
+USAGE
+  $ asyncapi start preview SPEC-FILE [-h] [-p <value>] [-b <value>] [-d <value>] [-x] [-l]
+
+ARGUMENTS
+   SPEC-FILE  the path to the file to be opened with studio or context name and is required.
+
+FLAGS
+  -b, --base=<value>    Path to the file which will act as a base. This is required when some properties need to be overwritten while bundling the file.
+  -d, --baseDir=<value> One relative/absolute path to directory relative to which paths to AsyncAPI Documents that should be bundled will be resolved.
+  -h, --help            Show ClI help.
+  -l, --suppressLogs    Pass this to suppress the detiled error logs.
+  -p, --port=<value>    port in which to start Studio in the preview mode.
+  -x, --xOrigin         Pass this switch to generate properties "x-origin" that will contain historical values of dereferenced "$ref"s.
+
+DESCRIPTION
+  starts a new local instance of Studio in minimal state bundling all the refs of the schema file and with no editing allowed. 
+```
+
+_See code: [src/commands/start/preview.ts](https://github.com/asyncapi/cli/blob/v2.16.4/src/commands/start/preview.ts)_
+
 
 ## `asyncapi validate [SPEC-FILE]`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@asyncapi/cli",
-  "version": "2.16.10",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asyncapi/cli",
-      "version": "2.16.10",
+      "version": "3.0.0",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.23",
@@ -20,7 +21,7 @@
         "@asyncapi/parser": "^3.3.0",
         "@asyncapi/protobuf-schema-parser": "^3.5.1",
         "@asyncapi/raml-dt-schema-parser": "^4.0.24",
-        "@asyncapi/studio": "^0.23.1",
+        "@asyncapi/studio": "^0.24.2",
         "@clack/prompts": "^0.7.0",
         "@oclif/core": "^4.2.9",
         "@oclif/plugin-autocomplete": "^3.2.26",
@@ -165,6 +166,25 @@
       "peerDependencies": {
         "openapi-types": ">=7"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.1.1.tgz",
+      "integrity": "sha512-hpRD68SV2OMcZCsrbdkccTw5FXjNDLo5OuqSHyHZfwweGsDWZwDJ2+gONyNAbazZclobMirACLw0lk8WVxIqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.2",
+        "@csstools/css-color-parser": "^3.0.8",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/@asyncapi/avro-schema-parser": {
       "version": "3.0.24",
@@ -667,24 +687,25 @@
       }
     },
     "node_modules/@asyncapi/react-component": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.4.10.tgz",
-      "integrity": "sha512-ejANS06yj1ZM4YDtsRi0g7h3EEJLGusewjzeugK+tGntNAKVZRvTPUXhbSDMhTARHuZXhUGLlITIno7N1aXapw==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-2.6.3.tgz",
+      "integrity": "sha512-Cs42mJxw8TQcc9RL66EAMF/b5T+ERq0a3DrJRkqr8v0URmUw/D4r/wIVpLApt9AgED4okSNDZfLJYSBUWyRk2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/avro-schema-parser": "^3.0.22",
-        "@asyncapi/openapi-schema-parser": "^3.0.22",
-        "@asyncapi/parser": "^3.0.14",
-        "@asyncapi/protobuf-schema-parser": "^3.2.12",
+        "@asyncapi/avro-schema-parser": "^3.0.24",
+        "@asyncapi/openapi-schema-parser": "^3.0.24",
+        "@asyncapi/parser": "^3.3.0",
+        "@asyncapi/protobuf-schema-parser": "^3.5.1",
         "highlight.js": "^10.7.2",
-        "isomorphic-dompurify": "^0.13.0",
+        "isomorphic-dompurify": "^2.14.0",
         "marked": "^4.0.14",
         "openapi-sampler": "^1.2.1",
-        "use-resize-observer": "^8.0.0"
+        "react-error-boundary": "^4.1.2",
+        "use-resize-observer": "^9.1.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@asyncapi/specs": {
@@ -695,9 +716,9 @@
       }
     },
     "node_modules/@asyncapi/studio": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/studio/-/studio-0.23.1.tgz",
-      "integrity": "sha512-63qhUg8NBZt7lLnc2SVx5hJbP/wylyDaeil70Dq9tfK0Q4tgwyUumT71vOz9RE8SkKsDKeEFZdIdpHkyCy0MGg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@asyncapi/studio/-/studio-0.24.2.tgz",
+      "integrity": "sha512-IHS5AYDhgu6bwgdMF1JqcZacJhtlOTQoFJfSJJ+7r9U5hW4IPdktD8AXAZhoe4fPm1sOoAfkxzAoT4uo58S+lQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.19",
@@ -705,7 +726,7 @@
         "@asyncapi/openapi-schema-parser": "^3.0.18",
         "@asyncapi/parser": "^3.2.2",
         "@asyncapi/protobuf-schema-parser": "^3.2.8",
-        "@asyncapi/react-component": "^1.2.2",
+        "@asyncapi/react-component": "^2.5.0",
         "@asyncapi/specs": "^6.5.4",
         "@codemirror/view": "^6.26.3",
         "@ebay/nice-modal-react": "^1.2.10",
@@ -727,7 +748,7 @@
         "js-yaml": "^4.1.0",
         "monaco-editor": "0.34.1",
         "monaco-yaml": "4.0.2",
-        "next": "14.2.3",
+        "next": "14.2.21",
         "postcss": "8.4.31",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -760,9 +781,9 @@
       }
     },
     "node_modules/@asyncapi/studio/node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
-      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.21.tgz",
+      "integrity": "sha512-HwEjcKsXtvszXz5q5Z7wCtrHeTTDSTgAbocz45PHMUjU3fBYInfvhR+ZhavDRUYLonm53aHZbB09QtJVJj8T7g==",
       "cpu": [
         "arm64"
       ],
@@ -776,9 +797,9 @@
       }
     },
     "node_modules/@asyncapi/studio/node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
-      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.21.tgz",
+      "integrity": "sha512-TSAA2ROgNzm4FhKbTbyJOBrsREOMVdDIltZ6aZiKvCi/v0UwFmwigBGeqXDA97TFMpR3LNNpw52CbVelkoQBxA==",
       "cpu": [
         "x64"
       ],
@@ -792,9 +813,9 @@
       }
     },
     "node_modules/@asyncapi/studio/node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
-      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.21.tgz",
+      "integrity": "sha512-0Dqjn0pEUz3JG+AImpnMMW/m8hRtl1GQCNbO66V1yp6RswSTiKmnHf3pTX6xMdJYSemf3O4Q9ykiL0jymu0TuA==",
       "cpu": [
         "arm64"
       ],
@@ -808,9 +829,9 @@
       }
     },
     "node_modules/@asyncapi/studio/node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
-      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.21.tgz",
+      "integrity": "sha512-Ggfw5qnMXldscVntwnjfaQs5GbBbjioV4B4loP+bjqNEb42fzZlAaK+ldL0jm2CTJga9LynBMhekNfV8W4+HBw==",
       "cpu": [
         "arm64"
       ],
@@ -824,9 +845,9 @@
       }
     },
     "node_modules/@asyncapi/studio/node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
-      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.21.tgz",
+      "integrity": "sha512-plykgB3vL2hB4Z32W3ktsfqyuyGAPxqwiyrAi2Mr8LlEUhNn9VgkiAl5hODSBpzIfWweX3er1f5uNpGDygfQVQ==",
       "cpu": [
         "arm64"
       ],
@@ -840,9 +861,9 @@
       }
     },
     "node_modules/@asyncapi/studio/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
-      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.21.tgz",
+      "integrity": "sha512-w5bacz4Vxqrh06BjWgua3Yf7EMDb8iMcVhNrNx8KnJXt8t+Uu0Zg4JHLDL/T7DkTCEEfKXO/Er1fcfWxn2xfPA==",
       "cpu": [
         "ia32"
       ],
@@ -856,9 +877,9 @@
       }
     },
     "node_modules/@asyncapi/studio/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
-      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.21.tgz",
+      "integrity": "sha512-sT6+llIkzpsexGYZq8cjjthRyRGe5cJVhqh12FmlbxHqna6zsDDK8UNaV7g41T6atFHCJUPeLb3uyAwrBwy0NA==",
       "cpu": [
         "x64"
       ],
@@ -869,15 +890,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@asyncapi/studio/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@asyncapi/studio/node_modules/@reactflow/background": {
@@ -982,10 +994,12 @@
       }
     },
     "node_modules/@asyncapi/studio/node_modules/next": {
-      "version": "14.2.3",
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.21.tgz",
+      "integrity": "sha512-rZmLwucLHr3/zfDMYbJXbw0ZeoBpirxkXuvsJbk7UPorvPYZhP7vq7aHbKnU7dQNCYIimRrbB2pp3xmf+wsYUg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.3",
+        "@next/env": "14.2.21",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -1000,15 +1014,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.3",
-        "@next/swc-darwin-x64": "14.2.3",
-        "@next/swc-linux-arm64-gnu": "14.2.3",
-        "@next/swc-linux-arm64-musl": "14.2.3",
-        "@next/swc-linux-x64-gnu": "14.2.3",
-        "@next/swc-linux-x64-musl": "14.2.3",
-        "@next/swc-win32-arm64-msvc": "14.2.3",
-        "@next/swc-win32-ia32-msvc": "14.2.3",
-        "@next/swc-win32-x64-msvc": "14.2.3"
+        "@next/swc-darwin-arm64": "14.2.21",
+        "@next/swc-darwin-x64": "14.2.21",
+        "@next/swc-linux-arm64-gnu": "14.2.21",
+        "@next/swc-linux-arm64-musl": "14.2.21",
+        "@next/swc-linux-x64-gnu": "14.2.21",
+        "@next/swc-linux-x64-musl": "14.2.21",
+        "@next/swc-win32-arm64-msvc": "14.2.21",
+        "@next/swc-win32-ia32-msvc": "14.2.21",
+        "@next/swc-win32-x64-msvc": "14.2.21"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -3568,6 +3582,116 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.2.tgz",
+      "integrity": "sha512-TklMyb3uBB28b5uQdxjReG4L80NxAqgrECqLZFQbyLekwwlcDDS8r3f07DKqeo8C4926Br0gf/ZDe17Zv4wIuw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.8.tgz",
+      "integrity": "sha512-pdwotQjCCnRPuNi06jFuP68cykU1f3ZWExLe/8MQ1LOs8Xq+fTkYgd+2V8mWUWMrOn9iS2HftPVaMZDaXzGbhQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
+      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
+      "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@ebay/nice-modal-react": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/@ebay/nice-modal-react/-/nice-modal-react-1.2.13.tgz",
@@ -5060,7 +5184,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.3",
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.21.tgz",
+      "integrity": "sha512-lXcwcJd5oR01tggjWJ6SrNNYFGuOOMB9c251wUNkjCpkoXOPkDeF/15c3mnVlBqrW4JJXb2kVxDFhC4GduJt2A==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -5128,7 +5254,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.3",
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.21.tgz",
+      "integrity": "sha512-uokj0lubN1WoSa5KKdThVPRffGyiWlm/vCc/cMkWOQHw69Qt0X1o3b2PyLLx8ANqlefILZh1EdfLRz9gVpG6tg==",
       "cpu": [
         "x64"
       ],
@@ -5142,7 +5270,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.3",
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.21.tgz",
+      "integrity": "sha512-iAEBPzWNbciah4+0yI4s7Pce6BIoxTQ0AGCkxn/UBuzJFkYyJt71MadYQkjPqCQCJAFQ26sYh7MOKdU+VQFgPg==",
       "cpu": [
         "x64"
       ],
@@ -7628,15 +7758,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "license": "MIT"
@@ -7863,15 +7984,6 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/dompurify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.4.0.tgz",
-      "integrity": "sha512-IDBwO5IZhrKvHFUl+clZxgf3hn2b/lU6H1KaBShPkQyGJUQ0xwebezIPSuiyGwfz1UzJWQl4M7BDxtHtCCPlTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/trusted-types": "*"
-      }
-    },
     "node_modules/@types/es-aggregate-error": {
       "version": "1.0.6",
       "license": "MIT",
@@ -8080,7 +8192,8 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/urijs": {
       "version": "1.19.25",
@@ -8433,13 +8546,6 @@
       "version": "1.0.1",
       "license": "MIT"
     },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "deprecated": "Use your platform's native atob() and btoa() methods instead",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "license": "ISC"
@@ -8464,43 +8570,12 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-globals": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^7.1.1",
-        "acorn-walk": "^7.1.1"
-      }
-    },
-    "node_modules/acorn-globals/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -9173,12 +9248,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/browser-process-hrtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -9977,29 +10046,18 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssom": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
-      "license": "MIT"
-    },
     "node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.0.tgz",
+      "integrity": "sha512-6r0NiY0xizYqfBvWp1G7WXJ06/bZyrk7Dc6PHql82C/pKGUTKu4yAX4Y8JPamb1ob9nBKuxWzCGTRuGwU3yxJQ==",
       "license": "MIT",
       "dependencies": {
-        "cssom": "~0.3.6"
+        "@asamuzakjp/css-color": "^3.1.1",
+        "rrweb-cssom": "^0.8.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
-    },
-    "node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -10102,17 +10160,16 @@
       "license": "MIT"
     },
     "node_modules/data-urls": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "license": "MIT",
       "dependencies": {
-        "abab": "^2.0.3",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -10440,33 +10497,14 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/domexception": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "license": "MIT",
-      "dependencies": {
-        "webidl-conversions": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/domexception/node_modules/webidl-conversions": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -10789,36 +10827,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/eslint": {
@@ -12651,7 +12659,6 @@
     },
     "node_modules/form-data": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -13452,15 +13459,15 @@
       }
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
-      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-encoding": "^1.0.5"
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/html-escaper": {
@@ -13490,17 +13497,25 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/http2-wrapper": {
@@ -14251,14 +14266,16 @@
       }
     },
     "node_modules/isomorphic-dompurify": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-0.13.0.tgz",
-      "integrity": "sha512-j2/kt/PGbxvfeEm1uiRLlttZkQdn3hFe1rMr/wm3qFnMXSIw0Nmqu79k+TIoSj+KOwO98Sz9TbuNHU7ejv7IZA==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.22.0.tgz",
+      "integrity": "sha512-A2xsDNST1yB94rErEnwqlzSvGllCJ4e8lDMe1OWBH2hvpfc/2qzgMEiDshTO1HwO+PIDTiYeOc7ZDB7Ds49BOg==",
       "license": "MIT",
       "dependencies": {
-        "@types/dompurify": "^2.1.0",
-        "dompurify": "^2.2.7",
-        "jsdom": "^16.5.2"
+        "dompurify": "^3.2.4",
+        "jsdom": "^26.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -14484,96 +14501,41 @@
       "license": "MIT"
     },
     "node_modules/jsdom": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
-      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.0.0.tgz",
+      "integrity": "sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==",
       "license": "MIT",
       "dependencies": {
-        "abab": "^2.0.5",
-        "acorn": "^8.2.4",
-        "acorn-globals": "^6.0.0",
-        "cssom": "^0.4.4",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^2.0.0",
-        "decimal.js": "^10.2.1",
-        "domexception": "^2.0.1",
-        "escodegen": "^2.0.0",
-        "form-data": "^3.0.0",
-        "html-encoding-sniffer": "^2.0.1",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.1",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.0",
-        "parse5": "6.0.1",
-        "saxes": "^5.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.0.0",
-        "w3c-hr-time": "^1.0.2",
-        "w3c-xmlserializer": "^2.0.0",
-        "webidl-conversions": "^6.1.0",
-        "whatwg-encoding": "^1.0.5",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.5.0",
-        "ws": "^7.4.6",
-        "xml-name-validator": "^3.0.0"
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.5.0"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jsdom/node_modules/form-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.3.tgz",
-      "integrity": "sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/jsdom/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/jsdom/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }
@@ -19048,9 +19010,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.18",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.18.tgz",
-      "integrity": "sha512-p1TRH/edngVEHVbwqWnxUViEmq5znDvyB+Sik5cmuLpGOIfDf/39zLiq3swPF8Vakqn+gvNiOQAZu8djYlQILA==",
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
       "license": "MIT"
     },
     "node_modules/nyc": {
@@ -19703,10 +19665,28 @@
       }
     },
     "node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "license": "MIT"
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/parserapiv1": {
       "name": "@asyncapi/parser",
@@ -20428,18 +20408,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/pubsub-js": {
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/pubsub-js/-/pubsub-js-1.9.5.tgz",
@@ -20452,12 +20420,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -20628,6 +20590,18 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.1.2.tgz",
+      "integrity": "sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-hot-toast": {
@@ -21107,12 +21081,6 @@
         "path-parse": "^1.0.5"
       }
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
-    },
     "node_modules/reserved": {
       "version": "0.1.2",
       "engines": {
@@ -21242,6 +21210,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "license": "MIT",
@@ -21333,15 +21307,15 @@
       "license": "MIT"
     },
     "node_modules/saxes": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -22407,6 +22381,24 @@
         "@popperjs/core": "^2.9.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.85",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.85.tgz",
+      "integrity": "sha512-gBdZ1RjCSevRPFix/hpaUWeak2/RNUZB4/8frF1r5uYMHjFptkiT0JXIebWvgI/0ZHXvxaUDDJshiA0j6GdL3w==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.85"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.85",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.85.tgz",
+      "integrity": "sha512-DTjUVvxckL1fIoPSb3KE7ISNtkWSawZdpfxGxwiIrZoO6EbHVDXXUIlIuWympPaeS+BLGyggozX/HTMsRAdsoA==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "license": "MIT",
@@ -22458,39 +22450,27 @@
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.0.tgz",
+      "integrity": "sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==",
       "license": "MIT",
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/traverse": {
@@ -22998,31 +22978,21 @@
       "version": "1.19.11",
       "license": "MIT"
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/urlpattern-polyfill": {
       "version": "8.0.2",
       "license": "MIT"
     },
     "node_modules/use-resize-observer": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-8.0.0.tgz",
-      "integrity": "sha512-n0iKSeiQpJCyaFh5JA0qsVLBIovsF4EIIR1G6XiBwKJN66ZrD4Oj62bjcuTAATPKiSp6an/2UZZxCf/67fk3sQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
+      "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": "16.8.0 - 18",
+        "react-dom": "16.8.0 - 18"
       }
     },
     "node_modules/use-sync-external-store": {
@@ -23104,30 +23074,20 @@
       "version": "3.0.8",
       "license": "MIT"
     },
-    "node_modules/w3c-hr-time": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
-      "license": "MIT",
-      "dependencies": {
-        "browser-process-hrtime": "^1.0.0"
-      }
-    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
-      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "license": "MIT",
       "dependencies": {
-        "xml-name-validator": "^3.0.0"
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/walk": {
@@ -23174,41 +23134,58 @@
       "license": "MIT"
     },
     "node_modules/webidl-conversions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10.4"
+        "node": ">=12"
       }
     },
     "node_modules/whatwg-encoding": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "license": "MIT",
       "dependencies": {
-        "iconv-lite": "0.4.24"
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
-      "license": "MIT"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.7.0",
-        "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -23411,10 +23388,13 @@
       }
     },
     "node_modules/xml-name-validator": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-      "license": "Apache-2.0"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@asyncapi/parser": "^3.3.0",
     "@asyncapi/protobuf-schema-parser": "^3.5.1",
     "@asyncapi/raml-dt-schema-parser": "^4.0.24",
-    "@asyncapi/studio": "^0.23.1",
+    "@asyncapi/studio": "^0.24.2",
     "@clack/prompts": "^0.7.0",
     "@oclif/core": "^4.2.9",
     "@oclif/plugin-autocomplete": "^3.2.26",

--- a/src/commands/start/preview.ts
+++ b/src/commands/start/preview.ts
@@ -5,7 +5,7 @@ import { load } from '../../core/models/SpecificationFile';
 import { startPreview } from '../../core/models/Preview';
 
 export default class PreviewStudio extends Command {
-  static readonly description = 'starts a new local instance of AsyncAPI studio in readOnly state with minimal UI and no editing';
+  static readonly description = 'starts a new local instance of Studio in minimal state bundling all the refs of the schema file and with no editing allowed.';
 
   static readonly flags = previewFlags();
 

--- a/src/commands/start/preview.ts
+++ b/src/commands/start/preview.ts
@@ -37,6 +37,6 @@ export default class PreviewStudio extends Command {
       }
     }
     this.metricsMetadata.port = previewPort;
-    startPreview(filePath as string,previewPort,flags.base,flags.baseDir,flags.xOrigin);
+    startPreview(filePath as string,previewPort,flags.base,flags.baseDir,flags.xOrigin,flags.detailedLog);
   }
 }

--- a/src/commands/start/preview.ts
+++ b/src/commands/start/preview.ts
@@ -32,6 +32,6 @@ export default class PreviewStudio extends Command {
       }
     }
     this.metricsMetadata.port = previewPort;
-    startPreview(filePath as string,flags.base,flags.baseDir,flags.xOrigin,flags.detailedLog,previewPort);
+    startPreview(filePath as string,flags.base,flags.baseDir,flags.xOrigin,flags.suppressLogs,previewPort);
   }
 }

--- a/src/commands/start/preview.ts
+++ b/src/commands/start/preview.ts
@@ -21,12 +21,8 @@ export default class PreviewStudio extends Command {
     const previewPort = flags.port;
 
     if (!filePath) {
-      try {
-        filePath = ((await load()).getFilePath());
-        this.log(`Loaded the specification from: ${filePath}`);
-      } catch (error) {
-        this.error('No file specified in the arguments. Please specify a file path.');
-      }
+      filePath = ((await load()).getFilePath());
+      this.log(`Loaded the specification from: ${filePath}`);
     }
     try {
       this.specFile = await load(filePath);

--- a/src/commands/start/preview.ts
+++ b/src/commands/start/preview.ts
@@ -25,7 +25,6 @@ export default class PreviewStudio extends Command {
         filePath = ((await load()).getFilePath());
         this.log(`Loaded the specification from: ${filePath}`);
       } catch (error) {
-        filePath = '';
         this.error('No file specified in the arguments. Please specify a file path.');
       }
     }
@@ -37,6 +36,6 @@ export default class PreviewStudio extends Command {
       }
     }
     this.metricsMetadata.port = previewPort;
-    startPreview(filePath as string,previewPort,flags.base,flags.baseDir,flags.xOrigin,flags.detailedLog);
+    startPreview(filePath as string,flags.base,flags.baseDir,flags.xOrigin,flags.detailedLog,previewPort);
   }
 }

--- a/src/commands/start/preview.ts
+++ b/src/commands/start/preview.ts
@@ -5,9 +5,9 @@ import { load } from '../../core/models/SpecificationFile';
 import { startPreview } from '../../core/models/Preview';
 
 export default class PreviewStudio extends Command {
-  static description = 'starts a new local instance of AsyncAPI studio in readOnly state with minimal UI and no editing';
+  static readonly description = 'starts a new local instance of AsyncAPI studio in readOnly state with minimal UI and no editing';
 
-  static flags = previewFlags();
+  static readonly flags = previewFlags();
 
   static readonly args = {
     'spec-file': Args.string({ description: 'spec path, url, or context-name', required: false }),
@@ -22,15 +22,15 @@ export default class PreviewStudio extends Command {
     
     let filePath : string | undefined = args['spec-file'] ?? flags.file;
     
-    const port = flags.port;
+    const previewPort = flags.port;
 
     if (!filePath) {
       try {
         filePath = ((await load()).getFilePath());
-        this.log(`Loaded specification from: ${filePath}`);
+        this.log(`Loaded the specification from: ${filePath}`);
       } catch (error) {
         filePath = '';
-        this.error('No file specified.');
+        this.error('No file specified in the arguments. Please specify a file path.');
       }
     }
     try {
@@ -40,7 +40,7 @@ export default class PreviewStudio extends Command {
         this.error(error as Error);
       }
     }
-    this.metricsMetadata.port = port;
-    startPreview(filePath as string,port);
+    this.metricsMetadata.port = previewPort;
+    startPreview(filePath as string,previewPort);
   }
 }

--- a/src/commands/start/preview.ts
+++ b/src/commands/start/preview.ts
@@ -10,15 +10,11 @@ export default class PreviewStudio extends Command {
   static readonly flags = previewFlags();
 
   static readonly args = {
-    'spec-file': Args.string({ description: 'spec path, url, or context-name', required: false }),
+    'spec-file': Args.string({ description: 'the path to the file to be opened with studio or context name', required: true }),
   };
 
   async run () {
     const {args,flags} = await this.parse(PreviewStudio);
-
-    if (flags.file) {
-      this.warn('The file flag has been removed and is being replaced by the argument spec-file. Please pass the filename directly like `asyncapi start studio asyncapi.yml`');
-    }
     
     let filePath : string | undefined = args['spec-file'] ?? flags.file;
     
@@ -41,6 +37,6 @@ export default class PreviewStudio extends Command {
       }
     }
     this.metricsMetadata.port = previewPort;
-    startPreview(filePath as string,previewPort);
+    startPreview(filePath as string,previewPort,flags.base,flags.baseDir,flags.xOrigin);
   }
 }

--- a/src/commands/start/preview.ts
+++ b/src/commands/start/preview.ts
@@ -41,6 +41,6 @@ export default class PreviewStudio extends Command {
       }
     }
     this.metricsMetadata.port = port;
-    startPreview(filePath as string);
+    startPreview(filePath as string,port);
   }
 }

--- a/src/commands/start/preview.ts
+++ b/src/commands/start/preview.ts
@@ -1,0 +1,46 @@
+import { Args } from '@oclif/core';
+import Command from '../../core/base';
+import { previewFlags } from '../../core/flags/start/preview.flags';
+import { load } from '../../core/models/SpecificationFile';
+import { startPreview } from '../../core/models/Preview';
+
+export default class PreviewStudio extends Command {
+  static description = 'starts a new local instance of AsyncAPI studio in readOnly state with minimal UI and no editing';
+
+  static flags = previewFlags();
+
+  static readonly args = {
+    'spec-file': Args.string({ description: 'spec path, url, or context-name', required: false }),
+  };
+
+  async run () {
+    const {args,flags} = await this.parse(PreviewStudio);
+
+    if (flags.file) {
+      this.warn('The file flag has been removed and is being replaced by the argument spec-file. Please pass the filename directly like `asyncapi start studio asyncapi.yml`');
+    }
+    
+    let filePath : string | undefined = args['spec-file'] ?? flags.file;
+    
+    const port = flags.port;
+
+    if (!filePath) {
+      try {
+        filePath = ((await load()).getFilePath());
+        this.log(`Loaded specification from: ${filePath}`);
+      } catch (error) {
+        filePath = '';
+        this.error('No file specified.');
+      }
+    }
+    try {
+      this.specFile = await load(filePath);
+    } catch (error) {
+      if (filePath) {
+        this.error(error as Error);
+      }
+    }
+    this.metricsMetadata.port = port;
+    startPreview(filePath as string);
+  }
+}

--- a/src/core/flags/start/preview.flags.ts
+++ b/src/core/flags/start/preview.flags.ts
@@ -1,0 +1,7 @@
+import { studioFlags } from './studio.flags';
+
+export const previewFlags = () => {
+  return {
+    ...studioFlags(),
+  };
+};

--- a/src/core/flags/start/preview.flags.ts
+++ b/src/core/flags/start/preview.flags.ts
@@ -7,5 +7,6 @@ export const previewFlags = () => {
     base: Flags.string({ char: 'b', description: 'Path to the file which will act as a base. This is required when some properties need to be overwritten while bundling with the file.' }),
     baseDir: Flags.string({ char: 'd', description: 'One relative/absolute path to directory relative to which paths to AsyncAPI Documents that should be bundled will be resolved.' }),
     xOrigin: Flags.boolean({ char: 'x', description: 'Pass this switch to generate properties "x-origin" that will contain historical values of dereferenced "$ref"s.' }),
+    detailedLog: Flags.boolean({char: 'l',description: 'Pass this to get detailed logs in case of any error relatd to bundling of files.',default: false})
   };
 };

--- a/src/core/flags/start/preview.flags.ts
+++ b/src/core/flags/start/preview.flags.ts
@@ -7,6 +7,6 @@ export const previewFlags = () => {
     base: Flags.string({ char: 'b', description: 'Path to the file which will act as a base. This is required when some properties need to be overwritten while bundling with the file.' }),
     baseDir: Flags.string({ char: 'd', description: 'One relative/absolute path to directory relative to which paths to AsyncAPI Documents that should be bundled will be resolved.' }),
     xOrigin: Flags.boolean({ char: 'x', description: 'Pass this switch to generate properties "x-origin" that will contain historical values of dereferenced "$ref"s.' }),
-    detailedLog: Flags.boolean({char: 'l',description: 'Pass this to get detailed logs in case of any error relatd to bundling of files.',default: false})
+    suppressLogs: Flags.boolean({char: 'l',description: 'Pass this to suppress the detiled error logs.',default: false})
   };
 };

--- a/src/core/flags/start/preview.flags.ts
+++ b/src/core/flags/start/preview.flags.ts
@@ -1,7 +1,11 @@
-import { studioFlags } from './studio.flags';
+import { Flags } from '@oclif/core';
 
 export const previewFlags = () => {
   return {
-    ...studioFlags(),
+    help: Flags.help({ char: 'h' }),
+    port: Flags.integer({ char: 'p', description: 'port in which to start Studio in the preview mode' }),
+    base: Flags.string({ char: 'b', description: 'Path to the file which will act as a base. This is required when some properties need to be overwritten while bundling with the file.' }),
+    baseDir: Flags.string({ char: 'd', description: 'One relative/absolute path to directory relative to which paths to AsyncAPI Documents that should be bundled will be resolved.' }),
+    xOrigin: Flags.boolean({ char: 'x', description: 'Pass this switch to generate properties "x-origin" that will contain historical values of dereferenced "$ref"s.' }),
   };
 };

--- a/src/core/models/Preview.ts
+++ b/src/core/models/Preview.ts
@@ -14,6 +14,7 @@ import { version as studioVersion } from '@asyncapi/studio/package.json';
 const sockets: any[] = [];
 const messageQueue: string[] = [];
 const filePathsToWatch: Set<string> = new Set<string>();
+let bundleError = true;
 
 export const DEFAULT_PORT = 3210;
 
@@ -27,7 +28,12 @@ export function startPreview(filePath:string,port: number = DEFAULT_PORT):void {
     throw new SpecificationFileNotFound(filePath);
   }
 
-  // Locate @asyncapi/studio package
+  bundle(filePath).then((doc) => {
+    if (doc) {
+      bundleError = false;
+    }
+  });
+
   const studioPath = path.dirname(require.resolve('@asyncapi/studio/package.json'));
   const app = next({
     dev: false,
@@ -129,7 +135,9 @@ export function startPreview(filePath:string,port: number = DEFAULT_PORT):void {
           'Warning: No file was provided, and we couldn\'t find a default file (like "asyncapi.yaml" or "asyncapi.json") in the current folder. Starting Studio with a blank workspace.'
         );
       }
-      open(url);
+      if (!bundleError) {
+        open(url);
+      }
     });
   });
 }

--- a/src/core/models/Preview.ts
+++ b/src/core/models/Preview.ts
@@ -144,6 +144,8 @@ export function startPreview(filePath:string,port: number = DEFAULT_PORT,base:st
       if (!bundleError) {
         open(url);
       }
+    }).on('error', (error) => {
+      console.error(`Failed to start server on port ${port}:`, error.message);
     });
   });
 }

--- a/src/core/models/Preview.ts
+++ b/src/core/models/Preview.ts
@@ -68,36 +68,31 @@ export function startPreview(filePath:string,port: number = DEFAULT_PORT):void {
       chokidar.watch([...filePathsToWatch]).on('all',(event) => {
         switch (event) {
         case 'add':
-          bundle(filePath).then((document) => {
+          bundle(filePath).then((intitalDocument) => {
             messageQueue.push(JSON.stringify({
               type: 'preview:file:added',
               code: (path.extname(filePath) === '.yaml' || path.extname(filePath) === '.yml') ? 
-                document.yml() : document.json()
+                intitalDocument.yml() : intitalDocument.json()
             }));
             sendQueuedMessages();
-          }).catch((error) => {
-            console.log('An error occured while bundling files. Please check console for error logs');
-            console.log(error);
+          }).catch((e) => {
+            console.log('An error occured while bundling files.\n',e);
           });
-
           break;
         case 'change':
-
-          bundle(filePath).then((document) => {
+          bundle(filePath).then((modifiedDocument) => {
             messageQueue.push(JSON.stringify({
               type: 'preview:file:changed',
               code: (path.extname(filePath) === '.yaml' || path.extname(filePath) === '.yml') ? 
-                document.yml() : document.json()
+                modifiedDocument.yml() : modifiedDocument.json()
             }));
             sendQueuedMessages();
           }).catch((error) => {
-            console.log('An error occured while bundling files. Please check console for error logs');
+            console.log('An error occured while bundling the modified files. \n');
             console.log(error);
           });
-
           break;      
         case 'unlink':
-
           messageQueue.push(JSON.stringify({
             type: 'preview:file:deleted',
             filePath,
@@ -111,7 +106,7 @@ export function startPreview(filePath:string,port: number = DEFAULT_PORT):void {
 
     server.on('upgrade', (request, socket, head) => {
       if (request.url === '/preview-server') { // can add request.headers['origin'] !== 'http://localhost:3210' check also
-        console.log('🔗 WebSocket connection established.');
+        console.log('🔗 WebSocket connection established for the preview.');
         wsServer.handleUpgrade(request, socket, head, (sock: any) => {
           wsServer.emit('connection', sock, request);
         });
@@ -124,7 +119,7 @@ export function startPreview(filePath:string,port: number = DEFAULT_PORT):void {
       const url = `http://localhost:${port}?previewServer=${port}&studio-version=${studioVersion}`;
       console.log(`🎉 Connected to Preview Server running at ${blueBright(url)}.`);
       console.log(`🌐 Open this URL in your web browser: ${blueBright(url)}`);
-      console.log(`🛑 If needed, press ${redBright('Ctrl + C')} to stop the process.`);
+      console.log(`🛑 If needed, press ${redBright('Ctrl + C')} to stop the server.`);
       
       if (filePath) {
         for (const entry of filePathsToWatch) {

--- a/src/core/models/Preview.ts
+++ b/src/core/models/Preview.ts
@@ -25,7 +25,7 @@ function isValidFilePath(filePath: string): boolean {
 }
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-export function startPreview(filePath:string,port: number = DEFAULT_PORT,base:string | undefined,baseDirectory:string | undefined ,xOrigin:boolean | undefined,detailedLog:boolean|undefined):void {
+export function startPreview(filePath:string,base:string | undefined,baseDirectory:string | undefined ,xOrigin:boolean | undefined,detailedLog:boolean|undefined,port: number = DEFAULT_PORT):void {
   if (filePath && !isValidFilePath(filePath)) {
     throw new SpecificationFileNotFound(filePath);
   }

--- a/src/core/models/Preview.ts
+++ b/src/core/models/Preview.ts
@@ -24,7 +24,7 @@ function isValidFilePath(filePath: string): boolean {
 }
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-export function startPreview(filePath:string,port: number = DEFAULT_PORT):void {
+export function startPreview(filePath:string,port: number = DEFAULT_PORT,base:string | undefined,baseDirectory:string | undefined ,xOrigin:boolean | undefined):void {
   if (filePath && !isValidFilePath(filePath)) {
     throw new SpecificationFileNotFound(filePath);
   }
@@ -71,9 +71,9 @@ export function startPreview(filePath:string,port: number = DEFAULT_PORT):void {
         switch (event) {
         case 'add':
           bundle([filePath],{
-            base: undefined,
-            baseDir: undefined,
-            xOrigin: undefined,
+            base,
+            baseDir: baseDirectory,
+            xOrigin,
           }).then((intitalDocument) => {
             messageQueue.push(JSON.stringify({
               type: 'preview:file:added',
@@ -87,9 +87,9 @@ export function startPreview(filePath:string,port: number = DEFAULT_PORT):void {
           break;
         case 'change':
           bundle([filePath],{
-            base: undefined,
-            baseDir: undefined,
-            xOrigin: undefined,
+            base,
+            baseDir: baseDirectory,
+            xOrigin,
           }).then((modifiedDocument) => {
             messageQueue.push(JSON.stringify({
               type: 'preview:file:changed',

--- a/src/core/models/Preview.ts
+++ b/src/core/models/Preview.ts
@@ -1,0 +1,181 @@
+import { SpecificationFileNotFound } from '../errors/specification-file';
+import { existsSync,readFileSync } from 'fs';
+import bundle from '@asyncapi/bundler';
+import { createServer } from 'http';
+import { WebSocketServer } from 'ws';
+import chokidar from 'chokidar';
+import open from 'open';
+import next from 'next';
+import path from 'path';
+import yaml from 'js-yaml';
+import { blueBright, redBright } from 'picocolors';
+import { version as studioVersion } from '@asyncapi/studio/package.json';
+
+const sockets: any[] = [];
+const messageQueue: string[] = [];
+const filePathsToWatch: Set<string> = new Set<string>();
+
+export const DEFAULT_PORT = 3210;
+
+function isValidFilePath(filePath: string): boolean {
+  return existsSync(filePath);
+}
+
+// eslint-disable-next-line sonarjs/cognitive-complexity
+export function startPreview(filePath:string,port: number = DEFAULT_PORT):void {
+  if (filePath && !isValidFilePath(filePath)) {
+    throw new SpecificationFileNotFound(filePath);
+  }
+
+  // Locate @asyncapi/studio package
+  const studioPath = path.dirname(require.resolve('@asyncapi/studio/package.json'));
+  const app = next({
+    dev: false,
+    dir: studioPath,
+    conf: {
+      distDir: 'build',
+    } as any,
+  });
+
+  const handle = app.getRequestHandler();
+  
+  const wsServer = new WebSocketServer({ noServer: true });
+
+  wsServer.on('connection',(socket:any) => {
+    sockets.push(socket);
+    sendQueuedMessages();
+  });
+
+  wsServer.on('close', (socket: any) => {
+    sockets.splice(sockets.findIndex(s => s === socket));
+  });
+
+  app.prepare().then(() => {
+    if (filePath) {
+      messageQueue.push(JSON.stringify({
+        type: 'preview:connected',
+        code: 'Preview server connected'
+      }));
+      sendQueuedMessages();
+      findPathsToWatchFromSchemaRef(filePath);
+      filePathsToWatch.add(filePath);
+      chokidar.watch([...filePathsToWatch]).on('all',(event) => {
+        switch (event) {
+        case 'add':
+          bundle(filePath).then((document) => {
+            messageQueue.push(JSON.stringify({
+              type: 'preview:file:added',
+              code: (path.extname(filePath) === '.yaml' || path.extname(filePath) === '.yml') ? 
+                document.yml() : document.json()
+            }));
+            sendQueuedMessages();
+          }).catch((error) => {
+            console.log('An error occured while bundling files. Please check console for error logs');
+            console.log(error);
+          });
+
+          break;
+        case 'change':
+
+          bundle(filePath).then((document) => {
+            messageQueue.push(JSON.stringify({
+              type: 'preview:file:changed',
+              code: (path.extname(filePath) === '.yaml' || path.extname(filePath) === '.yml') ? 
+                document.yml() : document.json()
+            }));
+            sendQueuedMessages();
+          }).catch((error) => {
+            console.log('An error occured while bundling files. Please check console for error logs');
+            console.log(error);
+          });
+
+          break;      
+        case 'unlink':
+
+          messageQueue.push(JSON.stringify({
+            type: 'preview:file:deleted',
+            filePath,
+          }));
+          sendQueuedMessages();
+          break;
+        }
+      });
+    }
+    const server = createServer((req, res) => handle(req, res));
+
+    server.on('upgrade', (request, socket, head) => {
+      if (request.url === '/preview-server') { // can add request.headers['origin'] !== 'http://localhost:3210' check also
+        console.log('🔗 WebSocket connection established.');
+        wsServer.handleUpgrade(request, socket, head, (sock: any) => {
+          wsServer.emit('connection', sock, request);
+        });
+      } else {
+        socket.destroy();
+      }
+    });
+  
+    server.listen(port, () => {
+      const url = `http://localhost:${port}?previewServer=${port}&studio-version=${studioVersion}`;
+      console.log(`🎉 Connected to Preview Server running at ${blueBright(url)}.`);
+      console.log(`🌐 Open this URL in your web browser: ${blueBright(url)}`);
+      console.log(`🛑 If needed, press ${redBright('Ctrl + C')} to stop the process.`);
+      
+      if (filePath) {
+        for (const entry of filePathsToWatch) {
+          console.log(`👁️ Watching changes on file ${blueBright(entry)}`);
+        }
+      } else {
+        console.warn(
+          'Warning: No file was provided, and we couldn\'t find a default file (like "asyncapi.yaml" or "asyncapi.json") in the current folder. Starting Studio with a blank workspace.'
+        );
+      }
+      open(url);
+    });
+  });
+}
+
+function sendQueuedMessages() {
+  console.log(sockets);
+  console.log(messageQueue);
+  while (messageQueue.length && sockets.length) {
+    const nextMessage = messageQueue.shift();
+    for (const socket of sockets) {
+      socket.send(nextMessage);
+    }
+  }
+}
+
+function isLocalRefAPath(key: string, value: any): boolean {
+  return (typeof value === 'string' && key === '$ref' && 
+    (value.startsWith('.') || value.startsWith('./') || 
+    value.startsWith('../') || !value.startsWith('#')));
+}
+
+function findPathsToWatchFromSchemaRef(filePath: string) {
+  if (filePath && !isValidFilePath(filePath)) {
+    throw new SpecificationFileNotFound(filePath);
+  }
+  const baseDir = path.dirname(path.resolve(filePath));
+  const document = yaml.load(readFileSync(filePath,'utf-8'));
+  const stack:object[] = [document as object];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+
+    if (current === null || typeof current !== 'object') {
+      continue;
+    }
+
+    for (const [key,value] of Object.entries(current)) {
+      if (isLocalRefAPath(key, value)) {
+        const absolutePath = path.resolve(baseDir, value);
+        filePathsToWatch.add(absolutePath);
+      }
+
+      if (value !== null && typeof value === 'object') {
+        stack.push(value);
+      }
+    }
+  }
+}
+

--- a/src/core/models/Preview.ts
+++ b/src/core/models/Preview.ts
@@ -135,8 +135,6 @@ export function startPreview(filePath:string,port: number = DEFAULT_PORT):void {
 }
 
 function sendQueuedMessages() {
-  console.log(sockets);
-  console.log(messageQueue);
   while (messageQueue.length && sockets.length) {
     const nextMessage = messageQueue.shift();
     for (const socket of sockets) {

--- a/src/core/models/Preview.ts
+++ b/src/core/models/Preview.ts
@@ -25,7 +25,7 @@ function isValidFilePath(filePath: string): boolean {
 }
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-export function startPreview(filePath:string,base:string | undefined,baseDirectory:string | undefined ,xOrigin:boolean | undefined,detailedLog:boolean|undefined,port: number = DEFAULT_PORT):void {
+export function startPreview(filePath:string,base:string | undefined,baseDirectory:string | undefined ,xOrigin:boolean | undefined,suppressLogs:boolean|undefined,port: number = DEFAULT_PORT):void {
   if (filePath && !isValidFilePath(filePath)) {
     throw new SpecificationFileNotFound(filePath);
   }
@@ -36,10 +36,11 @@ export function startPreview(filePath:string,base:string | undefined,baseDirecto
       bundleError = false;
     }
   }).catch((err) => {
-    if (detailedLog) {
+    if (suppressLogs) {
+      console.log(defaultErrorMessage);
+    } else {
       console.log(err);
     }
-    console.log(defaultErrorMessage);
   });
 
   const studioPath = path.dirname(require.resolve('@asyncapi/studio/package.json'));
@@ -88,10 +89,11 @@ export function startPreview(filePath:string,base:string | undefined,baseDirecto
             }));
             sendQueuedMessages();
           }).catch((e) => {
-            if (detailedLog) {
+            if (suppressLogs) {
+              console.log(defaultErrorMessage);
+            } else {
               console.log(e);
             }
-            console.log(defaultErrorMessage);
           });
           break;
         case 'change':
@@ -107,10 +109,11 @@ export function startPreview(filePath:string,base:string | undefined,baseDirecto
             }));
             sendQueuedMessages();
           }).catch((error) => {
-            if (detailedLog) {
+            if (suppressLogs) {
+              console.log(defaultErrorMessage);
+            } else {
               console.log(error);
             }
-            console.log(defaultErrorMessage);
           });
           break;      
         case 'unlink':

--- a/src/core/models/Preview.ts
+++ b/src/core/models/Preview.ts
@@ -105,12 +105,13 @@ export function startPreview(filePath:string,port: number = DEFAULT_PORT):void {
     const server = createServer((req, res) => handle(req, res));
 
     server.on('upgrade', (request, socket, head) => {
-      if (request.url === '/preview-server') { // can add request.headers['origin'] !== 'http://localhost:3210' check also
+      if (request.url === '/preview-server' && request.headers['origin'] === `http://localhost:${port}`) {
         console.log('🔗 WebSocket connection established for the preview.');
         wsServer.handleUpgrade(request, socket, head, (sock: any) => {
           wsServer.emit('connection', sock, request);
         });
       } else {
+        console.log('🔗 WebSocket connection not established.');
         socket.destroy();
       }
     });


### PR DESCRIPTION
**Description**

This PR introduces the changes to implement the new command `asyncapi start preview` to open the studio in a minimal `readOnly` mode along with bundling the ref files internally. An argument to file needs to be passed that is to be opened.

Approach :-

- First after the path to file is passed it is first validated that the file exist. After the validation is complete then using the function `findPathsToWatchFromSchemaRef` the path to ref files are extracted.
- This function uses a stack data structure based approach instead of recursion based as in the later one in case of very large schemas memory consumption will be too much and may cause overflow issues. This makes it not optimal to be implemented hence using stack based approach to get all the path to `ref` files from schema and then adding them to be watched for changes
- After the files are added to be watched then the server starts and websocket connection starts which before anything sends a verification message `preview:connected` to the frontend so that frontend of studio can confirm and set the `readOnly` mode in studio. 
- Then rest of the bundled contents of the file are sent and upon changes to any of the file the modified file is again bundled and message is sent to update the frontend. 
- Also the websocket connection is also validated that the request to establish a websocket connection is coming from localhost and specified port only to further establish that the readOnly is being set through this command only.

**Related issue(s)**
Resolves #1627 