### PR TITLE
fix: working on windows installation issue

### DIFF
--- a/.changeset/1762.md
+++ b/.changeset/1762.md
@@ -1,0 +1,9 @@
+---
+'@asyncapi/cli': patch
+---
+
+fix: working on windows installation issue
+
+- d02b929: Working on windows installation issue
+
+

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "/bin",
     "/lib",
     "/assets",
+    "/scripts",
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json"
   ],
@@ -159,7 +160,7 @@
     "pack:macos": "oclif pack macos && npm run pack:rename",
     "pack:linux": "oclif pack deb && npm run pack:rename",
     "pack:tarballs": "oclif pack tarballs -t linux-x64 && npm run pack:rename",
-    "pack:windows": "oclif pack win && npm run pack:rename",
+    "pack:windows": "node scripts/pack-windows-fix.js",
     "pack:rename": "node scripts/releasePackagesRename.js",
     "prepublishOnly": "npm run build",
     "pretest": "npm run build",

--- a/scripts/pack-windows-fix.js
+++ b/scripts/pack-windows-fix.js
@@ -1,0 +1,67 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const packageJson = require('../package.json');
+const version = packageJson.version;
+
+console.log(`Packaging AsyncAPI CLI version ${version} for Windows...`);
+
+const targetFile = path.resolve('node_modules/oclif/lib/tarballs/build.js');
+
+if (!fs.existsSync(targetFile)) {
+  console.error(`File not found: ${targetFile}`);
+  throw error;
+}
+
+console.log(`Found target file: ${targetFile}`);
+
+const backupPath = `${targetFile}.backup`;
+if (!fs.existsSync(backupPath)) {
+  fs.copyFileSync(targetFile, backupPath);
+  console.log(`Backed up original file to: ${backupPath}`);
+}
+
+let fileContent = fs.readFileSync(targetFile, 'utf8');
+
+if (fileContent.includes('--force-local')) {
+  console.log('Patching file to remove --force-local flag');
+  fileContent = fileContent.replace(/--force-local/g, '');
+  fs.writeFileSync(targetFile, fileContent);
+  console.log('File patched successfully');
+} else {
+  console.log('No --force-local flag found in the file. It may have been already patched.');
+}
+
+try {
+  console.log('Running oclif pack win...');
+  const oclifResult = spawnSync('oclif', ['pack', 'win'], {
+    stdio: 'inherit',
+    shell: true
+  });
+
+  if (oclifResult.status !== 0) {
+    console.error('Oclif packaging failed with status:', oclifResult.status);
+    throw error;
+  }
+
+  console.log('Running rename script...');
+  const renameResult = spawnSync('node', ['scripts/releasePackagesRename.js'], {
+    stdio: 'inherit',
+    shell: true
+  });
+
+  if (renameResult.status !== 0) {
+    console.error('Rename script failed with status:', renameResult.status);
+    throw error;
+  }
+  console.log('Windows packaging completed successfully!');
+} catch (err) {
+  console.error('Error during packaging:', err);
+} finally {
+  if (fs.existsSync(backupPath)) {
+    fs.copyFileSync(backupPath, targetFile);
+    console.log('Restored original file');
+    fs.unlinkSync(backupPath);
+    console.log('Removed backup file');
+  }
+}


### PR DESCRIPTION
Windows installation gives errors on a lot of files due to problems like:
-File path resolution in Windows : Edited the release packages rename file in scripts for the windows version
-Was getting tarball error on the usage a "--force-local" flag that isn't supported by Windows so created a wrapper to overcome it
-Currently getting error on 7z: Error: Command failed: 7z
    '7z' is not recognized as an internal or external command,
    operable program or batch file.
Working on resolving this and further issues encountered

Aims to resolve #1744