### PR TITLE
fix(docs): update link to preview.ts in usage documentation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -785,7 +785,7 @@ DESCRIPTION
   starts a new local instance of Studio in minimal state bundling all the refs of the schema file and with no editing allowed. 
 ```
 
-_See code: [src/commands/start/preview.ts](https://github.com/asyncapi/cli/blob/v2.16.4/src/commands/start/preview.ts)_
+_See code: [src/commands/start/preview.ts](https://github.com/asyncapi/cli/blob/master/src/commands/start/preview.ts)_
 
 
 ## `asyncapi validate [SPEC-FILE]`


### PR DESCRIPTION
This PR fixes the docs link for the new command `asyncapi start preview`. The broken link happened as the command files and docs were added in the same PR hence the correct link to command reference in docs can only be added after the command is added by the merging of that PR.

Related issues:-
None