### PR TITLE
feat: optimize Dockerfile to reduce image size and build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.git
+test
+docs
+*.log
+dist
+tmp
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,70 +1,36 @@
+# Stage 1: Build
 FROM node:20-alpine AS build
-
-# Copy the source code
-COPY ./ /tmp/source_code
-
-# Install dependencies
-RUN cd /tmp/source_code && npm install --ignore-scripts
-
-# Build the source code
-RUN cd /tmp/source_code && npm run build
-
-# create libraries directory
-RUN mkdir -p /libraries
-
-# Copy the lib, bin, node_modules, and package.json files to the /libraries directory
-RUN cp -r /tmp/source_code/lib /libraries
-RUN cp -r /tmp/source_code/assets /libraries
-RUN cp /tmp/source_code/package.json /libraries
-RUN cp /tmp/source_code/package-lock.json /libraries
-RUN cp /tmp/source_code/oclif.manifest.json /libraries
-
-# Copy the bin directory to the /libraries directory
-RUN cp -r /tmp/source_code/bin /libraries
-
-# Remove everything inside /tmp
-RUN rm -rf /tmp/*
-
-FROM node:20-alpine
-
-# Set ARG to explicit value to build chosen version. Default is "latest"
-ARG ASYNCAPI_CLI_VERSION=
-
-# Create a non-root user
-RUN addgroup -S myuser && adduser -S myuser -G myuser
-
 WORKDIR /app
 
-# Since 0.14.0 release of html-template chromium is needed for pdf generation
-ENV PUPPETEER_EXECUTABLE_PATH /usr/bin/chromium-browser
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
-# Since 0.30.0 release Git is supported and required as a dependency
-# Since 0.14.0 release of html-template chromium is needed for pdf generation.
-# More custom packages for specific template should not be added to this dockerfile. Instead, we should come up with some extensibility solution.
-RUN apk --update add git chromium && \
-    apk add --no-cache --virtual .gyp python3 make g++ && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm /var/cache/apk/*
+# Install dependencies
+COPY package*.json ./
+RUN npm install --ignore-scripts
 
-# Copy the libraries directory from the build stage
-COPY --from=build /libraries /libraries
+# Copy rest of the source and build
+COPY . .
+RUN npm run build && \
+    npm prune --omit=dev && \
+    rm -rf test docs .git
 
-# Install the dependencies
-RUN cd /libraries && npm install --production --ignore-scripts
+# Stage 2: Runtime
+FROM ghcr.io/puppeteer/puppeteer:20.8.0
 
-# Create a script that runs the desired command
-RUN ln -s /libraries/bin/run_bin /usr/local/bin/asyncapi
+# Switch to root to create user and set up permissions
+USER root
 
-# Make the script executable
-RUN chmod +x /usr/local/bin/asyncapi
+# Create non-root user
+RUN groupadd -r myuser && useradd -r -g myuser myuser
 
-# Change ownership to non-root user
-RUN chown -R myuser:myuser /libraries /usr/local/bin/asyncapi || echo "Failed to change ownership"
+# Copy built files from builder stage
+WORKDIR /app
+COPY --from=build /app /app
 
-RUN chown -R myuser:myuser /usr/local/lib/node_modules && \
-chown -R myuser:myuser /usr/local/bin
+# Create symlink and set permission, as root
+RUN ln -s /app/bin/run_bin /usr/local/bin/asyncapi && chmod +x /usr/local/bin/asyncapi
 
-# Switch to the non-root user
+# Now switch to non-root user for runtime
 USER myuser
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 ENTRYPOINT [ "asyncapi" ]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR optimizes the Docker build process for the AsyncAPI CLI. The current Docker image is large and takes a long time to build. These changes address both of those concerns:

### Changes Made:
- Rewrote the Dockerfile using a multi-stage build to separate dependencies and runtime.
- Switched to `ghcr.io/puppeteer/puppeteer:20.8.0` as the base image - it includes Chromium out of the box, which is required by some templates.
- Added a `.dockerignore` file to exclude unnecessary files like `node_modules`, `.git`, `test`, etc., reducing build context.
- Removed unused dev tools and temporary folders post-build to slim down the image.
- Used `npm prune --omit=dev` to eliminate devDependencies from the final image.
- Switched to a non-root user (`myuser`) for safer container execution.
- Created a symlink `/usr/local/bin/asyncapi` so the CLI can be invoked directly.

---

###  Performance Comparison

| Image Tag               | Size (GB) | Build Time (s) | Size Reduction         | Build Time Improvement |
|-------------------------|----------:|---------------:|------------------------|------------------------:|
| `asyncapi-cli-unoptimized` | 5.53 GB   | 530 s          | —                      | —                      |
| `asyncapi-cli-revised`     | 4.32 GB   | 245 s          | ↓ 1.21 GB (↓21.88%)     | ↓ 285 s (↓53.77%)       |

> Build and runtime tested locally using a fork of the repository.

---

###  How to Build & Run

```bash
docker build -t asyncapi-cli.

docker run -it --entrypoint sh asyncapi-cli

asyncapi --version
```

**Related issue(s)**
Resolves #1798
