### PR TITLE
ci: simplify caching configuration in release workflow

### DIFF
--- a/.github/workflows/release-server-api.yml
+++ b/.github/workflows/release-server-api.yml
@@ -47,8 +47,6 @@ jobs:
             asyncapi/server-api:${{ steps.version.outputs.value }}
             asyncapi/server-api:latest
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha
           
       - uses: meeDamian/sync-readme@82715041300710d9be7c726c9d6c683b70451087 #version 1.0.6 https://github.com/meeDamian/sync-readme/releases/tag/v1.0.6
         with:

--- a/.github/workflows/release-server-api.yml
+++ b/.github/workflows/release-server-api.yml
@@ -47,15 +47,9 @@ jobs:
             asyncapi/server-api:${{ steps.version.outputs.value }}
             asyncapi/server-api:latest
           platforms: linux/amd64,linux/arm64
-          cache-from: |
-            type=gha,scope=server-api
-            type=registry,ref=asyncapi/server-api:cache
-          cache-to: |
-            type=gha,mode=max,scope=server-api
-            type=registry,ref=asyncapi/server-api:cache,mode=max
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
-
+          cache-from: type=gha
+          cache-to: type=gha
+          
       - uses: meeDamian/sync-readme@82715041300710d9be7c726c9d6c683b70451087 #version 1.0.6 https://github.com/meeDamian/sync-readme/releases/tag/v1.0.6
         with:
           user: ${{secrets.DOCKER_USERNAME}}


### PR DESCRIPTION
**Description**

- Turns out GitHub caching doesnot work well with buildkit. https://github.com/moby/buildkit/issues/2804

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->