### PR TITLE
ci: ingress rules and alert configuration

### DIFF
--- a/src/apps/api/.do/app.yaml
+++ b/src/apps/api/.do/app.yaml
@@ -7,7 +7,8 @@ domain:
 
 ingress:
   rules:
-    - component: asyncapi-server-api
+    - component:
+        name: asyncapi-server-api
       match:
         path:
           prefix: /


### PR DESCRIPTION
**Description**

- Digitalocean has changed the app-spec structure leading to failing deploy.
<img width="1980" height="756" alt="image" src="https://github.com/user-attachments/assets/a75d9d88-b3ed-4745-911d-2a5ac83f83d3" />

- Tried the change locally:
<img width="2976" height="554" alt="image" src="https://github.com/user-attachments/assets/ae7ab055-ba3b-4691-aa57-1ca8bbe251b1" />


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->