### PR TITLE
fix:output flag renamed and writing to file functionality added to diff command 

### DIFF
--- a/src/apps/cli/commands/validate.ts
+++ b/src/apps/cli/commands/validate.ts
@@ -88,6 +88,7 @@ export default class Validate extends Command {
     flags: any,
   ): Promise<void> {
     const diagnosticsFormat = flags['diagnostics-format'] ?? 'stylish';
+    const writeOutput = flags['save-output'];
     const hasIssues =
       (result.data?.diagnostics && result.data.diagnostics.length > 0) ?? false;
     const isFailSeverity = result.data?.status === ValidationStatus.INVALID;
@@ -111,10 +112,10 @@ export default class Validate extends Command {
       flags['fail-severity'] ?? 'error',
     );
 
-    if (flags.output) {
+    if (writeOutput) {
       const { success, error } =
         await this.validationService.saveDiagnosticsToFile(
-          flags.output,
+          writeOutput,
           diagnosticsFormat,
           diagnosticsOutput,
         );
@@ -124,7 +125,7 @@ export default class Validate extends Command {
           exit: 1,
         });
       } else {
-        this.log(`Diagnostics saved to ${flags.output}`);
+        this.log(`Diagnostics saved to ${writeOutput}`);
       }
     } else {
       this.log(diagnosticsOutput);

--- a/src/apps/cli/internal/flags/parser.flags.ts
+++ b/src/apps/cli/internal/flags/parser.flags.ts
@@ -25,10 +25,10 @@ export function parserFlags({
       options: ['error', 'warn', 'info', 'hint'] as const,
       default: 'error',
     })(),
-    output: Flags.string({
+    'save-output': Flags.string({
       description:
         'The output file name. Omitting this flag the result will be printed in the console.',
-      char: 'o',
+      char: 's',
     }),
   };
 }


### PR DESCRIPTION
**Description**

This PR introduces the changes to fix the inconsistent naming of flags in commands `diff` , `validate` and `generate models`. The `-o` or `--output` flag present in these was inherited from `parserFlags()` and these commands also had a separate declaration and usage of `-o`  and `--output` flags among themselves and thus creating a confusion. 

With this PR the `-o` flag from `parserFlags()` is renamed to `-s` or `--save-output` which makes the name more verbose and descriptive along with eliminating any conflicts with declaration of flags with other commands.

In the `asyncapi diff` command which uses `parserFlags` and hence inherits the `-s` flag for saving the output functionality but previously lack implementation of it. Hence that was also added with this PR.

**Related issue(s)**

Resolves #1656 