### PR TITLE
fix: correct shebang command in bin/dev

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,4 +1,4 @@
-#!/usr/bin/env nod
+#!/usr/bin/env node
 
 const oclif = require('@oclif/core')
 


### PR DESCRIPTION
**Description**

Fixed a typo in the shebang line of bin/dev where ‘nod’ was written instead of ‘node’, causing execution errors.