### PR TITLE
fix: make static properties readonly to resolve SonarCloud issue S1444

### DIFF
--- a/.changeset/1883.md
+++ b/.changeset/1883.md
@@ -1,0 +1,10 @@
+---
+'@asyncapi/cli': patch
+---
+
+fix: make static properties readonly to resolve SonarCloud issue S1444
+
+- 0955372: fix: make static properties readonly to resolve SonarCloud issue S1444
+- d066eee: fix: make static properties readonly to resolve SonarCloud issue S1444
+
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@asyncapi/cli",
   "description": "All in one CLI for all AsyncAPI tools",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": "@asyncapi",
   "bin": {
     "asyncapi": "./bin/run_bin"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@asyncapi/cli",
   "description": "All in one CLI for all AsyncAPI tools",
-  "version": "4.1.0",
+  "version": "4.0.0",
   "author": "@asyncapi",
   "bin": {
     "asyncapi": "./bin/run_bin"

--- a/src/apps/cli/commands/config/auth/add.ts
+++ b/src/apps/cli/commands/config/auth/add.ts
@@ -4,10 +4,10 @@ import { blueBright } from 'picocolors';
 import { ConfigService, AuthEntry } from '@/domains/services/config.service';
 
 export default class AuthAdd extends Command {
-  static description =
+  static readonly description = 
     'Add an authentication config for resolving $ref files requiring HTTP Authorization.';
 
-  static args = {
+  static readonly args = {
     pattern: Args.string({
       required: true,
       description:
@@ -20,7 +20,7 @@ export default class AuthAdd extends Command {
     }),
   };
 
-  static flags = {
+  static readonly flags = {
     'auth-type': Flags.string({
       char: 'a',
       description: 'Authentication type (default is "Bearer")',


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- This PR fixes a SonarCloud issue related to mutable static fields (TypeScript rule S1444).
- Made public static fields `readonly` in `src/apps/cli/commands/config/auth/add.ts`

**Related issue(s)**
Part 1 - fixing #1881 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->