### PR TITLE
fix: update changeset action and cli

### DIFF
--- a/.github/workflows/release-with-changesets.yml
+++ b/.github/workflows/release-with-changesets.yml
@@ -127,7 +127,6 @@ jobs:
           publish: npx -p @changesets/cli@2.29.8 changeset publish
           setupGitUser: false
         env:
-          NODE_AUTH_TOKEN: ""
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           GIT_AUTHOR_NAME: asyncapi-bot
           GIT_AUTHOR_EMAIL: info@asyncapi.io


### PR DESCRIPTION
**Description**

- Release workflow still doesn't work. Trusted publishing is setup correctly.
- PR to check if updating changesets version fixes it.

**Related issue(s)**
