### PR TITLE
fix: registry url fixed

### DIFF
--- a/.github/workflows/release-with-changesets.yml
+++ b/.github/workflows/release-with-changesets.yml
@@ -127,8 +127,11 @@ jobs:
           publish: npx -p @changesets/cli@2.27.7 changeset publish
           setupGitUser: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Workaround for https://github.com/changesets/changesets/issues/1152
           NODE_AUTH_TOKEN: ""
+          NPM_TOKEN: ""
+          NPM_CONFIG_PROVENANCE: true
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           GIT_AUTHOR_NAME: asyncapi-bot
           GIT_AUTHOR_EMAIL: info@asyncapi.io
           GIT_COMMITTER_NAME: asyncapi-bot


### PR DESCRIPTION
**Description**

This pull request makes a minor adjustment to the Node.js setup in the GitHub Actions workflow by setting up the registry url in that step. 