### PR TITLE
feat: improve error message when generating fromTemplate #1728

### DIFF
--- a/.changeset/nasty-cougars-invent.md
+++ b/.changeset/nasty-cougars-invent.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Improve error messages when `generate fromTemplate` fails due to missing or incompatible templates.


### PR DESCRIPTION
Closes #1728

This PR improves error messages when `asyncapi generate fromTemplate` fails while working with templates.

## Changes
- Improve error handling in `GeneratorService.generate` so that generator failures are surfaced as clearer, user‑friendly messages in the CLI.
- Add a specific message when a template cannot be found or installed from the registry (for example, wrong name, missing scope, or 404‑like situations).
- Handle cases where the template directory is missing or corrupted (for example, `ENOENT` on the template path) and explain that the template installation or local folder is invalid.
- Clarify messages related to template–generator version incompatibility so users understand that a different generator or template version is required.
- Provide more informative hints for network or registry‑related failures that occur while resolving or installing a template (for example, unreachable registry or misconfigured URL).


## A screenshot of the core issue being resolved 
--
<img width="1212" height="835" alt="Screenshot 2025-12-21 233318" src="https://github.com/user-attachments/assets/c54d1e24-f11f-449c-af4e-1d586ee82a78" />

## Notes

The generic banner text (`Something went wrong` / `Generation failed`) is still printed by the existing CLI UI layer before the detailed `Generator Error: ...` message. This PR focuses on improving the generator error details and template‑related messages.



## Manual testing
Manual testing is done
In order to see the issue this PR proposes to solve, follow these steps:

In the CLI repository, with a valid asyncapi.yaml in the current directory:
Run commands:

### 1. Non‑existent template name (template cannot be found/installed)
---> asyncapi generate fromTemplate ./asyncapi.yaml not-installed-template -o /tmp/out1

### 2. Unscoped template name (should be @asyncapi/html-template)
---> asyncapi generate fromTemplate ./asyncapi.yaml html-template -o /tmp/out2

### 3. Valid scoped template but unreachable/invalid registry URL (network/registry error)
---> asyncapi generate fromTemplate ./asyncapi.yaml @asyncapi/html-template --registry-url https://fake-registry.example.com -o /tmp/out3