### PR TITLE
refactor: use node:fs import in convert service

### DIFF
--- a/src/domains/services/convert.service.ts
+++ b/src/domains/services/convert.service.ts
@@ -12,7 +12,7 @@ import {
   OpenAPIConvertVersion,
 } from '@asyncapi/converter';
 import { cyan, green } from 'picocolors';
-import { promises as fPromises } from 'fs';
+import { promises as fPromises } from 'node:fs';
 
 export class ConversionService extends BaseService {
   /**


### PR DESCRIPTION
Description: - Updated fs import to use the `node:` prefix in convert.service.ts
- Aligns with modern Node.js best practices and SonarCloud recommendations

Addresses: #1881