### PR TITLE
refactor: use node:fs and node:path in app-openapi

### DIFF
--- a/src/utils/app-openapi.ts
+++ b/src/utils/app-openapi.ts
@@ -1,5 +1,5 @@
-import { promises as fs } from 'fs';
-import path from 'path';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 
 import YAML from 'js-yaml';
 import $RefParser from '@apidevtools/json-schema-ref-parser';


### PR DESCRIPTION
**Description**

- Updated fs and path imports to use the `node:` prefix
- Improves consistency and maintainability
- Addresses SonarCloud code smell findings

See also #1881
