### PR TITLE
fix: windows release by aligning Node version with engine requirements

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -69,19 +69,15 @@ jobs:
         if: matrix.container == ''
         uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
         id: lockversion
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
       
       - name: Setup Node.js
         if: matrix.container == ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "${{ steps.lockversion.outputs.version }}"
-      
-      - if: matrix.npm_script == 'pack:windows'
-        name: install nodejs for windows
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      
+
       - name: Get version from package.json
         uses: actions/github-script@v6
         id: extractver


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

 - Fixes Windows release failures by aligning CI Node.js version with current engine requirements (Node ≥ 24, npm ≥ 11).
- Updates the release asset upload workflow to use the correct Node version, preventing missing Windows `.exe` artifacts.
- Ensures CI behavior is consistent with the release workflow and local development setup.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Resolves #1982