### PR TITLE
fix: suppress unparsed command warnings in config:versions and convert

### DIFF
--- a/src/apps/cli/commands/config/versions.ts
+++ b/src/apps/cli/commands/config/versions.ts
@@ -8,6 +8,7 @@ export default class Versions extends Command {
   static flags = helpFlag();
 
   async run() {
+    await this.parse(Versions);
     const dependencies: string[] = [];
     let dependency = '';
 

--- a/src/apps/cli/commands/convert.ts
+++ b/src/apps/cli/commands/convert.ts
@@ -31,6 +31,7 @@ export default class Convert extends Command {
   };
 
   async run() {
+    await this.parse(Convert);
     const { args, flags } = await this.parse(Convert);
     const filePath = applyProxyToPath(
       args['spec-file'],


### PR DESCRIPTION
**Description**

Fixes #2021 

This PR resolves the `[UnparsedCommand]` warnings appearing in the test logs for the `config:versions` and `convert` commands.

## Changes
- Added `await this.parse(Versions)` to `src/apps/cli/commands/config/versions.ts`
- Added `await this.parse(Convert)` to `src/apps/cli/commands/convert.ts`

## Verification
- Ran `npm run cli:test` locally.
- Verified that the `[UnparsedCommand]` warnings no longer appear in the logs.