### PR TITLE
fix: add timeout to registry validation to prevent indefinite hanging

### DIFF
--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -8,12 +8,34 @@ export function registryURLParser(input?: string) {
 
 export async function registryValidation(registryUrl?: string, registryAuth?: string, registryToken?: string) {
   if (!registryUrl) { return; }
+  
+  // Set timeout to prevent indefinite hanging
+  const timeoutMs = 10000; // 10 seconds
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  
   try {
-    const response = await fetch(registryUrl as string);
+    // Use HEAD request for lightweight validation
+    const response = await fetch(registryUrl as string, {
+      method: 'HEAD',
+      signal: controller.signal
+    });
+    
+    clearTimeout(timeoutId);
+    
     if (response.status === 401 && !registryAuth && !registryToken) {
       throw new Error('You Need to pass either registryAuth in username:password encoded in Base64 or need to pass registryToken');
     }
-  } catch {
-    throw new Error(`Can't fetch registryURL: ${registryUrl}`);
+  } catch (error) {
+    clearTimeout(timeoutId);
+    
+    // Provide specific error messages
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Registry URL validation timed out after ${timeoutMs/1000}s: ${registryUrl}`);
+    }
+    if (error instanceof Error && error.message.includes('registryAuth')) {
+      throw error; // Re-throw auth errors as-is
+    }
+    throw new Error(`Can't fetch registryURL: ${registryUrl}. Error: ${error instanceof Error ? error.message : String(error)}`);
   }
 }


### PR DESCRIPTION
## What this PR does

Fixes #2027 - CLI hangs indefinitely when `--registry-url` points to an unreachable host.

### Changes Made:
- Added `AbortController` with 10 second timeout to prevent indefinite hanging
- Changed HTTP method from GET to HEAD for lightweight validation
- Improved error messages to distinguish between timeout and network errors
- Properly clears timeout to avoid memory leaks

### Testing:
- Manual testing with unreachable URLs (blackholed IPs)
- Verified timeout triggers correctly after 10 seconds
- Confirmed proper error messages are shown

### Related Issue:
Part of Bounty Program 2026-04 (#2039)

### Wallet for Bounty:
`[wallet removed]`