### PR TITLE
fix: add timeout to registry validation to prevent indefinite hangs

### DIFF
--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -8,12 +8,22 @@ export function registryURLParser(input?: string) {
 
 export async function registryValidation(registryUrl?: string, registryAuth?: string, registryToken?: string) {
   if (!registryUrl) { return; }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000); // 10 second timeout
   try {
-    const response = await fetch(registryUrl as string);
+    const response = await fetch(registryUrl as string, {
+      method: 'HEAD',
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
     if (response.status === 401 && !registryAuth && !registryToken) {
       throw new Error('You Need to pass either registryAuth in username:password encoded in Base64 or need to pass registryToken');
     }
-  } catch {
-    throw new Error(`Can't fetch registryURL: ${registryUrl}`);
+  } catch (err: any) {
+    clearTimeout(timeout);
+    if (err.name === 'AbortError') {
+      throw new Error(`Registry URL timed out after 10 seconds: ${registryUrl}`);
+    }
+    throw new Error(`Can't fetch registryURL: ${registryUrl} — ${err.message}`);
   }
 }


### PR DESCRIPTION

## Description
Fixes the CLI hanging indefinitely when `--registry-url` points to an unreachable host.

## Changes
- Added `AbortController` with 10 second timeout to prevent indefinite hangs
- Changed from `GET` to `HEAD` request for lighter weight validation  
- Improved error messages to preserve original error and indicate timeout reason

Fixes https://github.com/asyncapi/cli/issues/2027
