### PR TITLE
fix: add timeout to registry URL validation to prevent indefinite hang

### DIFF
--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -8,12 +8,22 @@ export function registryURLParser(input?: string) {
 
 export async function registryValidation(registryUrl?: string, registryAuth?: string, registryToken?: string) {
   if (!registryUrl) { return; }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10000);
   try {
-    const response = await fetch(registryUrl as string);
+    const response = await fetch(registryUrl as string, {
+      method: 'HEAD',
+      signal: controller.signal,
+    });
     if (response.status === 401 && !registryAuth && !registryToken) {
       throw new Error('You Need to pass either registryAuth in username:password encoded in Base64 or need to pass registryToken');
     }
-  } catch {
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Connection to registryURL timed out after 10s: ${registryUrl}`);
+    }
     throw new Error(`Can't fetch registryURL: ${registryUrl}`);
+  } finally {
+    clearTimeout(timer);
   }
 }


### PR DESCRIPTION
## Description

Fixes #2027

The `registryValidation()` function calls `fetch(registryUrl)` with no timeout. When the URL points to an unreachable host (e.g., a black-holed IP like `10.255.255.1`), the CLI hangs indefinitely waiting for the OS-level TCP timeout.

## Changes

- Added `AbortController` with 10-second timeout to the `fetch` call in `registryValidation()`
- Switched HTTP method from `GET` to `HEAD` (only need to check reachability, not download body)
- Added distinct error messages: timeout-specific vs generic network error
- Added `finally` block to clean up the timer

## How it works

```typescript
const controller = new AbortController();
const timer = setTimeout(() => controller.abort(), 10000);
try {
  const response = await fetch(registryUrl, {
    method: 'HEAD',
    signal: controller.signal,
  });
  // ... existing auth check
} catch (error) {
  if (error.name === 'AbortError') {
    throw new Error(`Connection to registryURL timed out after 10s: ${registryUrl}`);
  }
  throw new Error(`Can't fetch registryURL: ${registryUrl}`);
} finally {
  clearTimeout(timer);
}
```

## Testing

Tested with unreachable host — CLI now fails after 10 seconds with a clear error message instead of hanging indefinitely.