### PR TITLE
fix(registry): add timeout and use HEAD request in registryValidation

### DIFF
--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -6,10 +6,12 @@ export function registryURLParser(input?: string) {
   }
 }
 
+const REGISTRY_TIMEOUT_MS = 5000;
+
 export async function registryValidation(registryUrl?: string, registryAuth?: string, registryToken?: string) {
   if (!registryUrl) { return; }
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 10_000); // 10 second timeout
+  const timeout = setTimeout(() => controller.abort(), REGISTRY_TIMEOUT_MS);
   try {
     const response = await fetch(registryUrl as string, {
       method: 'HEAD',
@@ -22,8 +24,8 @@ export async function registryValidation(registryUrl?: string, registryAuth?: st
   } catch (err: any) {
     clearTimeout(timeout);
     if (err.name === 'AbortError') {
-      throw new Error(`Registry URL timed out after 10 seconds: ${registryUrl}`);
+      throw new Error(`Registry URL timed out after ${REGISTRY_TIMEOUT_MS / 1000}s: ${registryUrl}. The host is unreachable or too slow.`);
     }
-    throw new Error(`Can't fetch registryURL: ${registryUrl} — ${err.message}`);
+    throw new Error(`Can't fetch registryURL: ${registryUrl}`);
   }
 }

--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -8,12 +8,22 @@ export function registryURLParser(input?: string) {
 
 export async function registryValidation(registryUrl?: string, registryAuth?: string, registryToken?: string) {
   if (!registryUrl) { return; }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000); // 10 second timeout
   try {
-    const response = await fetch(registryUrl as string);
+    const response = await fetch(registryUrl as string, {
+      method: 'HEAD',
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
     if (response.status === 401 && !registryAuth && !registryToken) {
       throw new Error('You Need to pass either registryAuth in username:password encoded in Base64 or need to pass registryToken');
     }
-  } catch {
-    throw new Error(`Can't fetch registryURL: ${registryUrl}`);
+  } catch (err: any) {
+    clearTimeout(timeout);
+    if (err.name === 'AbortError') {
+      throw new Error(`Registry URL timed out after 10 seconds: ${registryUrl}`);
+    }
+    throw new Error(`Can't fetch registryURL: ${registryUrl} — ${err.message}`);
   }
 }

--- a/test/unit/utils/registry.test.ts
+++ b/test/unit/utils/registry.test.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import { registryURLParser, registryValidation } from '../../../src/utils/generate/registry';
+
+describe('registryURLParser()', () => {
+  it('should return undefined for empty input', () => {
+    expect(registryURLParser(undefined)).to.equal(undefined);
+    expect(registryURLParser('')).to.equal(undefined);
+  });
+
+  it('should throw for invalid URL without protocol', () => {
+    expect(() => registryURLParser('not-a-url')).to.throw('Invalid --registry-url flag. The param requires a valid http/https url.');
+    expect(() => registryURLParser('ftp://example.com')).to.throw('Invalid --registry-url flag. The param requires a valid http/https url.');
+  });
+
+  it('should accept valid http URL', () => {
+    expect(() => registryURLParser('http://example.com')).to.not.throw();
+  });
+
+  it('should accept valid https URL', () => {
+    expect(() => registryURLParser('https://example.com')).to.not.throw();
+  });
+});
+
+describe('registryValidation()', () => {
+  it('should return undefined when no registryUrl is provided', async () => {
+    const result = await registryValidation(undefined, undefined, undefined);
+    expect(result).to.equal(undefined);
+  });
+
+  it('should throw when URL is unreachable (timeout)', async () => {
+    // 10.255.255.1 is a blackhole IP - will never respond
+    const blackholeUrl = 'http://10.255.255.1:9999';
+    try {
+      await registryValidation(blackholeUrl, undefined, undefined);
+      expect.fail('Should have thrown');
+    } catch (err: any) {
+      expect(err.message).to.include('timed out');
+      expect(err.message).to.include(blackholeUrl);
+    }
+  });
+
+  it('should throw when URL is unreachable (connection refused)', async () => {
+    // localhost:9 is unlikely to have anything listening
+    const url = 'http://localhost:9';
+    try {
+      await registryValidation(url, undefined, undefined);
+      expect.fail('Should have thrown');
+    } catch (err: any) {
+      expect(err.message).to.include('Can\'t fetch registryURL');
+    }
+  });
+});


### PR DESCRIPTION
## Description
Fixes #2027 - CLI hangs indefinitely when `--registry-url` points to an unreachable host (no timeout handling).

## Changes

- **Add AbortController with 5s timeout** to prevent indefinite hangs when registry is unreachable
- **Use HEAD request** instead of GET for lighter network footprint
- **Meaningful timeout error** message: `Registry URL timed out after 5s: <url>. The host is unreachable or too slow.`
- **Unit tests** added for `registryURLParser` and `registryValidation` including timeout behavior

## Root Cause

The original `registryValidation()` in `src/utils/generate/registry.ts` called `fetch()` without:
- No `AbortController` / timeout
- No signal to abort
- Used default GET (downloads full response body unnecessarily)
- Error message was opaque

## Testing

```bash
# Before fix — hangs indefinitely:
asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template --registry-url http://10.255.255.1

# After fix — fails fast with clear message:
# Error: Registry URL timed out after 5s: http://10.255.255.1. The host is unreachable or too slow.
```

## Files Changed

- `src/utils/generate/registry.ts` — add timeout, use HEAD, proper error messages
- `test/unit/utils/registry.test.ts` — new unit tests