### PR TITLE
fix: add timeout and error handling to registry URL validation

### DIFF
--- a/.changeset/clever-flowers-dance.md
+++ b/.changeset/clever-flowers-dance.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: add timeout and error handling to registry URL validation

--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -1,3 +1,5 @@
+const REGISTRY_TIMEOUT_MS = 5000;
+
 export function registryURLParser(input?: string) {
   if (!input) { return; }
   const isURL = /^https?:/;
@@ -8,12 +10,27 @@ export function registryURLParser(input?: string) {
 
 export async function registryValidation(registryUrl?: string, registryAuth?: string, registryToken?: string) {
   if (!registryUrl) { return; }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REGISTRY_TIMEOUT_MS);
+
   try {
-    const response = await fetch(registryUrl as string);
+    const response = await fetch(registryUrl as string, {
+      method: 'HEAD',
+      signal: controller.signal,
+    });
     if (response.status === 401 && !registryAuth && !registryToken) {
       throw new Error('You Need to pass either registryAuth in username:password encoded in Base64 or need to pass registryToken');
     }
-  } catch {
-    throw new Error(`Can't fetch registryURL: ${registryUrl}`);
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Registry URL '${registryUrl}' is unreachable (timed out after ${REGISTRY_TIMEOUT_MS / 1000}s). Please verify the URL is correct and accessible.`);
+    }
+    if (error instanceof Error && error.message.includes('registryAuth')) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to reach registry URL '${registryUrl}': ${message}`);
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/test/unit/utils/registry.test.ts
+++ b/test/unit/utils/registry.test.ts
@@ -1,0 +1,38 @@
+import { registryURLParser, registryValidation } from '../../../src/utils/generate/registry';
+
+describe('registryURLParser', () => {
+  it('should return undefined for undefined input', () => {
+    expect(registryURLParser(undefined)).toBeUndefined();
+  });
+
+  it('should not throw for valid http URL', () => {
+    expect(() => registryURLParser('http://registry.npmjs.org')).not.toThrow();
+  });
+
+  it('should not throw for valid https URL', () => {
+    expect(() => registryURLParser('https://registry.npmjs.org')).not.toThrow();
+  });
+
+  it('should throw for non-http URL', () => {
+    expect(() => registryURLParser('ftp://registry.npmjs.org')).toThrow('Invalid --registry-url flag');
+  });
+
+  it('should throw for plain string', () => {
+    expect(() => registryURLParser('not-a-url')).toThrow('Invalid --registry-url flag');
+  });
+});
+
+describe('registryValidation', () => {
+  it('should return undefined when no registryUrl is provided', async () => {
+    await expect(registryValidation(undefined)).resolves.toBeUndefined();
+  });
+
+  it('should time out for unreachable hosts', async () => {
+    // 10.255.255.1 is a non-routable IP that will never respond
+    await expect(registryValidation('http://10.255.255.1')).rejects.toThrow(/unreachable.*timed out/i);
+  }, 10000);
+
+  it('should throw a descriptive error for invalid hosts', async () => {
+    await expect(registryValidation('http://this-host-does-not-exist-at-all.invalid')).rejects.toThrow(/Unable to reach registry URL/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2027

The CLI hangs indefinitely when `--registry-url` points to an unreachable host because `registryValidation()` calls `fetch()` with no timeout or abort mechanism.

## Changes

**`src/utils/generate/registry.ts`:**
- Added `AbortController` with a **5-second timeout** so unreachable hosts fail fast
- Switched from `GET` to `HEAD` for lightweight URL validation (no need to download the full response body)
- Surface descriptive error messages that distinguish between timeout vs. other network errors
- Re-throw auth errors (401) correctly without masking them

**`test/unit/utils/registry.test.ts`** (new):
- Unit tests for `registryURLParser` (valid/invalid URL formats)
- Unit tests for `registryValidation` (timeout on unreachable host, error on invalid hostname)

## Before (broken)
\\\
$ asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template --registry-url http://10.255.255.1
# CLI hangs forever...
\\\

## After (fixed)
\\\
$ asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template --registry-url http://10.255.255.1
Error: Registry URL 'http://10.255.255.1' is unreachable (timed out after 5s). Please verify the URL is correct and accessible.
\\\
