### PR TITLE
fix: add timeout to registry URL connection check

### DIFF
--- a/.changeset/add-timeout-to-registry-url-check.md
+++ b/.changeset/add-timeout-to-registry-url-check.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: add timeout and AbortController to registry URL validation to prevent CLI hang on unreachable endpoints

--- a/cli/src/utils/generate/registry.ts
+++ b/cli/src/utils/generate/registry.ts
@@ -1,0 +1,40 @@
+import fetch, { AbortController } from 'node-fetch'; // Assuming `node-fetch` is used. If `fetch` is globally available (Node.js 18+), AbortController is also global, and this line can be adjusted to `const AbortController = globalThis.AbortController;` or simply rely on global scope.
+
+const REGISTRY_TIMEOUT_MS = 5000; // 5 seconds timeout for registry validation
+
+export async function registryValidation(registryUrl: string): Promise<void> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REGISTRY_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(registryUrl, {
+      method: 'HEAD', // Use HEAD for a lightweight check, as we only care about reachability
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      // If the response is not OK (e.g., 404, 500), it implies the URL is reachable but not a valid registry endpoint or has server-side issues.
+      throw new Error(
+        `Registry URL '${registryUrl}' returned an unsuccessful status ${response.status} (${response.statusText}). ` +
+        `It might not be a valid registry endpoint or is experiencing server issues.`,
+      );
+    }
+  } catch (error: any) {
+    if (error.name === 'AbortError') {
+      // Handle timeout specifically
+      throw new Error(
+        `Failed to connect to registry URL '${registryUrl}' within ${REGISTRY_TIMEOUT_MS / 1000} seconds. ` +
+        `This typically indicates a network issue, an incorrect URL, or that the registry host is unreachable/slow.`,
+      );
+    } else {
+      // Handle other network-related errors (DNS lookup failed, connection refused, etc.)
+      throw new Error(
+        `Failed to connect to registry URL '${registryUrl}'. ` +
+        `Please ensure the host is reachable and the URL is correct. ` +
+        `Original network error: ${error.message}`,
+      );
+    }
+  } finally {
+    clearTimeout(timeoutId); // Ensure the timeout is cleared to prevent resource leaks
+  }
+}

--- a/cli/src/utils/generate/registry.ts
+++ b/cli/src/utils/generate/registry.ts
@@ -1,5 +1,3 @@
-import fetch, { AbortController } from 'node-fetch'; // Assuming `node-fetch` is used. If `fetch` is globally available (Node.js 18+), AbortController is also global, and this line can be adjusted to `const AbortController = globalThis.AbortController;` or simply rely on global scope.
-
 const REGISTRY_TIMEOUT_MS = 5000; // 5 seconds timeout for registry validation
 
 export async function registryValidation(registryUrl: string): Promise<void> {
@@ -7,34 +5,24 @@ export async function registryValidation(registryUrl: string): Promise<void> {
   const timeoutId = setTimeout(() => controller.abort(), REGISTRY_TIMEOUT_MS);
 
   try {
-    const response = await fetch(registryUrl, {
-      method: 'HEAD', // Use HEAD for a lightweight check, as we only care about reachability
+    await fetch(registryUrl, {
+      method: 'HEAD', // Use HEAD for a lightweight reachability check
       signal: controller.signal,
     });
-
-    if (!response.ok) {
-      // If the response is not OK (e.g., 404, 500), it implies the URL is reachable but not a valid registry endpoint or has server-side issues.
-      throw new Error(
-        `Registry URL '${registryUrl}' returned an unsuccessful status ${response.status} (${response.statusText}). ` +
-        `It might not be a valid registry endpoint or is experiencing server issues.`,
-      );
-    }
-  } catch (error: any) {
+  } catch (error: any) { // Use 'any' for error type to handle both AbortError and other network errors
     if (error.name === 'AbortError') {
-      // Handle timeout specifically
       throw new Error(
-        `Failed to connect to registry URL '${registryUrl}' within ${REGISTRY_TIMEOUT_MS / 1000} seconds. ` +
-        `This typically indicates a network issue, an incorrect URL, or that the registry host is unreachable/slow.`,
-      );
-    } else {
-      // Handle other network-related errors (DNS lookup failed, connection refused, etc.)
-      throw new Error(
-        `Failed to connect to registry URL '${registryUrl}'. ` +
-        `Please ensure the host is reachable and the URL is correct. ` +
-        `Original network error: ${error.message}`,
+        `Connection to registry URL '${registryUrl}' timed out after ${REGISTRY_TIMEOUT_MS / 1000} seconds. ` +
+        `Please ensure the URL is correct and the host is reachable.`
       );
     }
+    // Handle other network-related errors (e.g., DNS resolution failure, connection refused)
+    throw new Error(
+      `Failed to connect to registry URL '${registryUrl}'. ` +
+      `Network error: ${error.message}. ` +
+      `Please check your network connection and the provided registry URL.`
+    );
   } finally {
-    clearTimeout(timeoutId); // Ensure the timeout is cleared to prevent resource leaks
+    clearTimeout(timeoutId);
   }
 }


### PR DESCRIPTION
Closes #2027

## What changed
This fix introduces robust timeout handling, uses a lightweight HEAD request, and provides clearer error messages for unreachable registry URLs within the `registryValidation` function.

## Files modified
- `cli/src/utils/generate/registry.ts`

---
*Draft PR — please review before merging.*