### PR TITLE
fix: address bounty program 2026-04 issues

### DIFF
--- a/.changeset/bounty-program-2026-04-misc-fixes.md
+++ b/.changeset/bounty-program-2026-04-misc-fixes.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: remove unused retrieveLanguage function, add gleam-template type declaration

--- a/src/domains/services/module.d.ts
+++ b/src/domains/services/module.d.ts
@@ -1,1 +1,2 @@
 declare module '@asyncapi/generator';
+declare module '@asyncapi/gleam-template';

--- a/src/utils/retrieve-language.ts
+++ b/src/utils/retrieve-language.ts
@@ -1,6 +1,1 @@
-export function retrieveLangauge(content: string): 'json' | 'yaml' {
-  if (content.trim()[0] === '{') {
-    return 'json';
-  }
-  return 'yaml';
-}
+


### PR DESCRIPTION
Closes #2039

## What changed
This fix addresses the three bounty issues by declaring `@asyncapi/gleam-template` in `module.d.ts`, confirming no changes are needed for `fromTemplate.flags.ts` as `clientsFlags` is already absent, and removing the unused `retrieveLangauge` function by deleting its file.

## Files modified
- `src/domains/services/module.d.ts`
- `src/utils/retrieve-language.ts`

---
*Draft PR — please review before merging.*