### PR TITLE
fix: add timeout, HEAD method, and meaningful errors to registryValidation

### DIFF
--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -8,12 +8,22 @@ export function registryURLParser(input?: string) {
 
 export async function registryValidation(registryUrl?: string, registryAuth?: string, registryToken?: string) {
   if (!registryUrl) { return; }
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
   try {
-    const response = await fetch(registryUrl as string);
+    const response = await fetch(registryUrl as string, {
+      method: 'HEAD',
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
     if (response.status === 401 && !registryAuth && !registryToken) {
       throw new Error('You Need to pass either registryAuth in username:password encoded in Base64 or need to pass registryToken');
     }
-  } catch {
-    throw new Error(`Can't fetch registryURL: ${registryUrl}`);
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Registry URL unreachable (timeout after 5s): ${registryUrl}`);
+    }
+    throw new Error(`Can't fetch registryURL: ${registryUrl} — ${error instanceof Error ? error.message : String(error)}`);
   }
 }


### PR DESCRIPTION
## Description
Adds a 5-second timeout to the registry URL validation to prevent the CLI from hanging indefinitely when the registry URL is unreachable.

## Changes
- **Timeout**: Added AbortController with 5-second timeout to fail fast
- **HEAD method**: Changed from default GET to HEAD for lighter-weight validation  
- **Better errors**: Include original error message and handle AbortError specifically with clear messaging
- **Fixes**: Resolves the indefinite hang issue described in asyncapi/cli#2027

## Testing
Run: asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template --registry-url http://10.255.255.1
CLI should fail within 5 seconds with a meaningful error instead of hanging indefinitely.