### PR TITLE
fix: add timeout to registryValidation to prevent indefinite hang

### DIFF
--- a/.changeset/registry-timeout-fix.md
+++ b/.changeset/registry-timeout-fix.md
@@ -1,0 +1,5 @@
+---
+"cli": patch
+---
+
+fix: add timeout to registryValidation fetch to prevent indefinite hang on unreachable registry URLs

--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -9,11 +9,23 @@ export function registryURLParser(input?: string) {
 export async function registryValidation(registryUrl?: string, registryAuth?: string, registryToken?: string) {
   if (!registryUrl) { return; }
   try {
-    const response = await fetch(registryUrl as string);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+    const response = await fetch(registryUrl as string, {
+      method: 'HEAD',
+      signal: controller.signal
+    });
+
+    clearTimeout(timeoutId);
+
     if (response.status === 401 && !registryAuth && !registryToken) {
       throw new Error('You Need to pass either registryAuth in username:password encoded in Base64 or need to pass registryToken');
     }
-  } catch {
+  } catch (error: any) {
+    if (error.name === 'AbortError') {
+      throw new Error(`Registry URL timed out after 5 seconds: ${registryUrl}. Please check if the URL is reachable.`);
+    }
     throw new Error(`Can't fetch registryURL: ${registryUrl}`);
   }
 }

--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -12,7 +12,7 @@ export async function registryValidation(registryUrl?: string, registryAuth?: st
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
-    const response = await fetch(registryUrl as string, {
+    const response = await fetch(registryUrl, {
       method: 'HEAD',
       signal: controller.signal
     });
@@ -22,8 +22,8 @@ export async function registryValidation(registryUrl?: string, registryAuth?: st
     if (response.status === 401 && !registryAuth && !registryToken) {
       throw new Error('You Need to pass either registryAuth in username:password encoded in Base64 or need to pass registryToken');
     }
-  } catch (error: any) {
-    if (error.name === 'AbortError') {
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AbortError') {
       throw new Error(`Registry URL timed out after 5 seconds: ${registryUrl}. Please check if the URL is reachable.`);
     }
     throw new Error(`Can't fetch registryURL: ${registryUrl}`);

--- a/test/unit/utils/registry.test.ts
+++ b/test/unit/utils/registry.test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-unused-expressions */
+import { expect } from 'chai';
+import { registryValidation, registryURLParser } from '../../../src/utils/generate/registry';
+
+describe('registryURLParser()', () => {
+  it('should return undefined for empty input', () => {
+    expect(registryURLParser()).to.be.undefined;
+  });
+
+  it('should throw for non-URL input', () => {
+    expect(() => registryURLParser('not-a-url')).to.throw('Invalid --registry-url flag');
+  });
+
+  it('should accept http URLs', () => {
+    expect(() => registryURLParser('http://localhost:8080')).to.not.throw();
+  });
+
+  it('should accept https URLs', () => {
+    expect(() => registryURLParser('https://example.com')).to.not.throw();
+  });
+});
+
+describe('registryValidation()', () => {
+  it('should return undefined when no registryUrl is provided', async function() {
+    const result = await registryValidation();
+    expect(result).to.be.undefined;
+  });
+
+  it('should throw timeout error for unreachable URL', async function() {
+    // Use a non-routable IP that will cause a timeout
+    try {
+      await registryValidation('http://10.255.255.1');
+      expect.fail('Should have thrown an error');
+    } catch (err) {
+      expect((err as Error).message).to.include('timed out');
+    }
+  });
+});


### PR DESCRIPTION
Fixes #2027

## Problem
`registryValidation()` in `src/utils/generate/registry.ts` uses `fetch()` with no timeout. When `--registry-url` points to an unreachable host (e.g., blackholed IP), the CLI hangs indefinitely.

## Changes
- Add `AbortController` with 5-second timeout to the fetch call
- Use HTTP `HEAD` instead of `GET` for lighter weight registry validation
- Detect `AbortError` and throw a clear timeout message: "Registry URL timed out after 5 seconds"
- Preserve existing behavior for auth errors (401) and network errors

## Testing
- All existing unit tests pass (`npm run unit:test`)
- Manual test: running with unreachable URL now fails fast with clear error instead of hanging