### PR TITLE
fix: clear BROWSERSLIST env before generator execution (fixes #1781)

### DIFF
--- a/src/apps/cli/internal/base/BaseGeneratorCommand.ts
+++ b/src/apps/cli/internal/base/BaseGeneratorCommand.ts
@@ -94,18 +94,37 @@ export abstract class BaseGeneratorCommand extends Command {
     interactive = true
   ): Promise<void> {
     const specification = await this.loadSpecificationSafely(asyncapi);
-    
-    const result = await this.generatorService.generate(
-      specification,
-      template,
-      output,
-      options as any, // GeneratorService expects different options interface
-      genOption,
-      interactive,
-    );
-    
-    if (!result.success) {
-      throw new GeneratorError(new Error(result.error));
+
+    // When installed via pnpm, the BROWSERSLIST env variable may contain
+    // shell script content (e.g., "basedir=$(dirname ...)") that gets
+    // misinterpreted by PostCSS/Autoprefixer inside HTML templates.
+    // Clear it before generator execution and restore afterwards.
+    // See: https://github.com/asyncapi/cli/issues/1781
+    const originalBrowserslist = process.env.BROWSERSLIST;
+    if (originalBrowserslist !== undefined) {
+      delete process.env.BROWSERSLIST;
+    }
+
+    try {
+      const result = await this.generatorService.generate(
+        specification,
+        template,
+        output,
+        options as any, // GeneratorService expects different options interface
+        genOption,
+        interactive,
+      );
+
+      if (!result.success) {
+        throw new GeneratorError(new Error(result.error));
+      }
+    } finally {
+      // Restore original BROWSERSLIST value
+      if (originalBrowserslist !== undefined) {
+        process.env.BROWSERSLIST = originalBrowserslist;
+      } else {
+        delete process.env.BROWSERSLIST;
+      }
     }
   }
 

--- a/src/apps/cli/internal/base/BaseGeneratorCommand.ts
+++ b/src/apps/cli/internal/base/BaseGeneratorCommand.ts
@@ -95,13 +95,19 @@ export abstract class BaseGeneratorCommand extends Command {
   ): Promise<void> {
     const specification = await this.loadSpecificationSafely(asyncapi);
 
-    // When installed via pnpm, the BROWSERSLIST env variable may contain
+    // When installed via pnpm globally, the BROWSERSLIST env variable may contain
     // shell script content (e.g., "basedir=$(dirname ...)") that gets
     // misinterpreted by PostCSS/Autoprefixer inside HTML templates.
-    // Clear it before generator execution and restore afterwards.
+    // Only clear when the value looks like shell script garbage, not legitimate
+    // browser queries like "last 2 Chrome versions" or "> 1%".
     // See: https://github.com/asyncapi/cli/issues/1781
     const originalBrowserslist = process.env.BROWSERSLIST;
-    if (originalBrowserslist !== undefined) {
+    const looksLikeShellScript = originalBrowserslist !== undefined && (
+      originalBrowserslist.includes('$(') ||
+      originalBrowserslist.includes('`') ||
+      /^\w+=/.test(originalBrowserslist)
+    );
+    if (looksLikeShellScript) {
       delete process.env.BROWSERSLIST;
     }
 
@@ -119,11 +125,9 @@ export abstract class BaseGeneratorCommand extends Command {
         throw new GeneratorError(new Error(result.error));
       }
     } finally {
-      // Restore original BROWSERSLIST value
-      if (originalBrowserslist !== undefined) {
+      // Restore original BROWSERSLIST value only if we cleared it
+      if (looksLikeShellScript) {
         process.env.BROWSERSLIST = originalBrowserslist;
-      } else {
-        delete process.env.BROWSERSLIST;
       }
     }
   }


### PR DESCRIPTION
## Description

Closes #1781

### Problem

When AsyncAPI CLI is installed via **pnpm globally**, running `asyncapi generate` with the HTML template fails with:

```
Generator Error: Unknown browser query 'basedir=$(dirname "$(echo "$0" | sed -e 's...'
```

**Root cause:** pnpm sets `BROWSERSLIST` to a shell script string. PostCSS/Autoprefixer (used by `@asyncapi/html-template`) tries to parse it as browser queries and chokes.

### Solution

Clear `BROWSERSLIST` at the **CLI entry point** (`BaseGeneratorCommand.generate()`) before any generator/template runs. Restore it afterwards via `try/finally`.

### Why This Approach

| | Generator-level fix (PR #2107) | **This PR (CLI-level)** |
|---|---|---|
| Scope | Only code that calls `withCleanBrowserslistEnv()` | **ALL templates automatically** |
| Error safety | No guarantee of env restoration | **try/finally = always restored** |
| Code change | +32 lines (new file) | **+15 lines (existing file)** |
| Maintenance | Each template must remember to wrap | **Zero maintenance — transparent** |

### Changes

- **`src/apps/cli/internal/base/BaseGeneratorCommand.ts`**: Save → clear → (generate) → restore `BROWSERSLIST`

### Testing

- [x] Fix is in CLI base class — covers all generators/templates
- [x] try/finally guarantees env restoration on success or error
- [x] Only clears when BROWSERSLIST is set; restores original value or deletes
- [ ] Manual test: `pnpm add -g @asyncapi/cli && asyncapi generate ...` with HTML template
