### PR TITLE
fix: suppress UnparsedCommand warnings in config:versions

### DIFF
--- a/src/apps/cli/commands/config/versions.ts
+++ b/src/apps/cli/commands/config/versions.ts
@@ -8,6 +8,7 @@ export default class Versions extends Command {
   static flags = helpFlag();
 
   async run() {
+    await this.parse(Versions);
     const dependencies: string[] = [];
     let dependency = '';
 


### PR DESCRIPTION
Fixes #2021

## Changes
- Added `await this.parse(Versions)` to the `config:versions` command to ensure all arguments are properly parsed before execution, suppressing the `\[UnparsedCommand]` warning in test logs.

Note: The `convert` command already had `this.parse()` call, so only `config:versions` needed the fix.

## Verification
- Run `npm run cli:test` and verify no `\[UnparsedCommand]` warnings appear for the config:versions command.