### PR TITLE
fix: watch mode crash with TypeError isLocalTemplate

### DIFF
--- a/src/utils/generate/watcher.ts
+++ b/src/utils/generate/watcher.ts
@@ -195,7 +195,7 @@ export async function runWatchMode(
     watcher = new Watcher(watchDir, ignorePaths);
   }
 
-  if (!await thisArg.isLocalTemplate(path.resolve(generatorClass.DEFAULT_TEMPLATES_DIR, templateName))) {
+  if (!await isLocalTemplate(path.resolve(generatorClass.DEFAULT_TEMPLATES_DIR, templateName))) {
     thisArg.warn(`WARNING: ${template} is a remote template. Changes may be lost on subsequent installations.`);
   }
 


### PR DESCRIPTION
Fixes #2018

## Changes
- Fixed `thisArg.isLocalTemplate(...)` to `isLocalTemplate(...)` in `src/utils/generate/watcher.ts`
- `isLocalTemplate` is a standalone exported function, not a method on the command instance (`thisArg`)

## Verification
1. Run: `asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template --watch ./out`
2. Verify that initial generation completes and watcher starts without crashing with `TypeError: thisArg.isLocalTemplate is not a function`