### PR TITLE
feat: add --ruleset flag for custom Spectral rules

### DIFF
--- a/src/apps/cli/internal/flags/validate.flags.ts
+++ b/src/apps/cli/internal/flags/validate.flags.ts
@@ -24,5 +24,10 @@ export const validateFlags = () => {
       required: false,
       default: false,
     }),
+    ruleset: Flags.string({
+      char: 'r',
+      description: 'Path to a custom Spectral ruleset file for validation.',
+      required: false,
+    }),
   };
 };

--- a/src/domains/services/validation.service.ts
+++ b/src/domains/services/validation.service.ts
@@ -290,7 +290,9 @@ export class ValidationService extends BaseService {
       const suppressedWarnings = options.suppressWarnings ?? [];
       let activeParser: Parser;
 
-      if (suppressAllWarnings || suppressedWarnings.length) {
+      if (options.ruleset) {
+        activeParser = this.buildParserWithCustomRuleset(options.ruleset);
+      } else if (suppressAllWarnings || suppressedWarnings.length) {
         activeParser = await this.buildAndRegisterCustomParser(
           specFile,
           suppressedWarnings,
@@ -340,6 +342,23 @@ export class ValidationService extends BaseService {
         },
       },
     });
+  }
+
+  /**
+   * Creates a parser with a custom ruleset file.
+   */
+  private buildParserWithCustomRuleset(rulesetPath: string): Parser {
+    const parser = new Parser({
+      ruleset: rulesetPath,
+      __unstable: {
+        resolver: {
+          cache: false,
+          resolvers: [createHttpWithAuthResolver()],
+        },
+      },
+    });
+    this.registerSchemaParsers(parser);
+    return parser;
   }
 
   /**

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -90,6 +90,7 @@ export interface ValidationOptions {
   output?: string;
   suppressWarnings?: string[];
   suppressAllWarnings?: boolean;
+  ruleset?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes #1900

## Changes
- Added `--ruleset` / `-r` flag to the `validate` command in `src/apps/cli/internal/flags/validate.flags.ts`
- Added `ruleset?` to `ValidationOptions` interface in `src/interfaces/index.ts`
- Updated `ValidationService.validateDocument()` to use a custom ruleset parser when `--ruleset` is provided
- Added `buildParserWithCustomRuleset()` method that creates a Parser with the specified ruleset file path

## Usage
```bash
asyncapi validate spec.yaml --ruleset ./my-custom-rules.yaml
asyncapi validate spec.yaml -r .spectral.json
```

## Verification
1. Create a custom Spectral ruleset file (e.g., `.spectral.yaml`)
2. Run: `asyncapi validate <spec-file> --ruleset <ruleset-file>`
3. Verify validation uses the custom ruleset instead of defaults