### PR TITLE
fix: skip metrics submission on fatal generation errors (fixes #2010)

### DIFF
--- a/src/apps/cli/internal/base.ts
+++ b/src/apps/cli/internal/base.ts
@@ -114,7 +114,10 @@ export default abstract class extends Command {
   }
   async finally(error: Error | undefined): Promise<any> {
     await super.finally(error);
-    this.metricsMetadata['success'] = error === undefined;
+    if (error) {
+      return;
+    }
+    this.metricsMetadata['success'] = true;
     await this.recordActionFinished(
       this.id as string,
       this.metricsMetadata,


### PR DESCRIPTION
## Summary

When a command fails with an error, the `finally()` handler still attempted to submit anonymous usage metrics via `recordActionFinished()`. This could fail independently (e.g. network error when flushing to NewRelic), producing a misleading secondary error message that obscures the actual cause of failure.

## Changes

- **`src/apps/cli/internal/base.ts`**: In `finally()`, return early when `error` is set instead of proceeding to record metrics. This ensures only the real error is shown to the user.

## Reproduction (from issue)

```bash
mkdir out && echo test > out/file.txt
asyncapi generate asyncapi.yaml @asyncapi/html-template --output ./out
```

**Before:** Two errors — the real one plus `Skipping submitting anonymous metrics due to the following error: TypeError: fetch failed`
**After:** Only the actual generator error is displayed.