### PR TITLE
fix: add timeout and use HEAD for registry URL validation

### DIFF
--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -9,11 +9,23 @@ export function registryURLParser(input?: string) {
 export async function registryValidation(registryUrl?: string, registryAuth?: string, registryToken?: string) {
   if (!registryUrl) { return; }
   try {
-    const response = await fetch(registryUrl as string);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    const response = await fetch(registryUrl as string, {
+      method: 'HEAD',
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
     if (response.status === 401 && !registryAuth && !registryToken) {
       throw new Error('You Need to pass either registryAuth in username:password encoded in Base64 or need to pass registryToken');
     }
-  } catch {
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Registry URL timed out after 5s: ${registryUrl}`);
+    }
+    if (error instanceof Error && error.message.startsWith('You Need to pass')) {
+      throw error;
+    }
     throw new Error(`Can't fetch registryURL: ${registryUrl}`);
   }
 }


### PR DESCRIPTION
## Summary
- Adds 5-second timeout via `AbortController` to `registryValidation()` fetch call
- Switches from `GET` to `HEAD` for lightweight registry reachability check
- Provides specific error message for timeout ("Registry URL timed out after 5s") vs generic network errors

## Root Cause
`fetch()` in `src/utils/generate/registry.ts` had no timeout and no abort signal, causing the CLI to hang indefinitely when `--registry-url` points to an unreachable host (e.g., blackholed IP).

## Test Plan
- [x] Tested with unreachable URL (`http://10.255.255.1`) — CLI now exits with timeout error after 5s
- [x] Tested with valid registry URL — works as before
- [x] Tested with 401 response — auth error still propagated correctly

Fixes #2027