### PR TITLE
fix: support slash-based branch names and multi-dot file extensions in GitHub URL parsing

### DIFF
--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -237,11 +237,11 @@ export async function fileExists(name: string): Promise<boolean> {
       return true;
     }
 
-    const extension = name.split('.')[1];
+    const extension = name.split('.').pop()?.toLowerCase();
 
     const allowedExtenstion = ['yml', 'yaml', 'json'];
 
-    if (!allowedExtenstion.includes(extension)) {
+    if (!extension || !allowedExtenstion.includes(extension)) {
       throw new ErrorLoadingSpec('invalid file', name);
     }
 

--- a/src/domains/services/validation.service.ts
+++ b/src/domains/services/validation.service.ts
@@ -65,17 +65,40 @@ const isValidGitHubBlobUrl = (url: string): boolean => {
  * Convert GitHub web URL to API URL
  */
 const convertGitHubWebUrl = (url: string): string => {
-  // Remove fragment from URL before processing
   const urlWithoutFragment = url.split('#')[0];
 
   // Handle GitHub web URLs like: https://github.com/owner/repo/blob/branch/path
-  // eslint-disable-next-line no-useless-escape
-  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/;
-  const match = urlWithoutFragment.match(githubWebPattern);
-
-  if (match) {
-    const [, owner, repo, branch, filePath] = match;
-    return `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`;
+  // Support branch names with slashes (e.g., feature/new-validation)
+  const githubUrlPrefix = 'https://github.com/';
+  if (urlWithoutFragment.startsWith(githubUrlPrefix)) {
+    const afterPrefix = urlWithoutFragment.slice(githubUrlPrefix.length);
+    const parts = afterPrefix.split('/');
+    
+    if (parts.length >= 4 && parts[2] === 'blob') {
+      const owner = parts[0];
+      const repo = parts[1];
+      // Everything after 'blob/' is branch + file path
+      const branchAndPath = parts.slice(3).join('/');
+      
+      // Find the file path by looking for the last segment with an extension
+      // or assume the last segment is the file
+      const segments = branchAndPath.split('/');
+      let filePathIndex = segments.length - 1;
+      
+      // Work backwards to find where file path likely starts
+      // (look for segments with file extensions)
+      for (let i = segments.length - 1; i >= 0; i--) {
+        if (segments[i].includes('.') || i === segments.length - 1) {
+          filePathIndex = i;
+          break;
+        }
+      }
+      
+      const branch = segments.slice(0, filePathIndex).join('/');
+      const filePath = segments.slice(filePathIndex).join('/');
+      
+      return `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`;
+    }
   }
 
   return url;


### PR DESCRIPTION
## Description

Fixes [#1940](https://github.com/asyncapi/cli/issues/1940)

This PR fixes two bugs in the CLI:

### 1. GitHub URL Parsing Bug

**Problem**: The regex pattern assumed branch names don't contain `/`, causing failures for valid URLs like:
```
https://github.com/org/repo/blob/feature/new-validation/spec.yaml
```

**Solution**: Rewrote the URL parsing logic to:
- Parse owner, repo, and the combined branch+path
- Work backwards from the filename to separate branch from file path
- Correctly handle branch names with slashes

### 2. File Extension Detection Bug

**Problem**: Used `name.split('.')[1]` which fails for:
- Files with multiple dots: `my.asyncapi.yaml` → incorrectly gets "asyncapi" instead of "yaml"
- Files without extensions: `asyncapi` → undefined, causes crash

**Solution**: 
- Use `.pop()` to get the last segment after splitting by `.`
- Add proper undefined check for files without extensions
- Convert to lowercase for case-insensitive comparison

---

**Testing**:
- [ ] GitHub URL with slash-based branch (e.g. `feature/new-validation`) works correctly
- [ ] Multi-dot filenames (e.g. `my.asyncapi.yaml`) are validated correctly
- [ ] Files without extensions don't cause crashes
