### PR TITLE
fix: use standalone isLocalTemplate instead of thisArg.isLocalTemplate (#2018)

### DIFF
--- a/src/utils/generate/watcher.ts
+++ b/src/utils/generate/watcher.ts
@@ -195,7 +195,7 @@ export async function runWatchMode(
     watcher = new Watcher(watchDir, ignorePaths);
   }
 
-  if (!await thisArg.isLocalTemplate(path.resolve(generatorClass.DEFAULT_TEMPLATES_DIR, templateName))) {
+  if (!await isLocalTemplate(path.resolve(generatorClass.DEFAULT_TEMPLATES_DIR, templateName))) {
     thisArg.warn(`WARNING: ${template} is a remote template. Changes may be lost on subsequent installations.`);
   }
 


### PR DESCRIPTION
## Summary

Fixed a bug where `thisArg.isLocalTemplate(...)` was incorrectly called instead of the standalone `isLocalTemplate(...)` function at line 198 of `src/utils/generate/watcher.ts`.

The `isLocalTemplate` function is defined at line 11 as an exported standalone function, not as a method on `thisArg`. This fix corrects the incorrect reference.

## Related Issue

Fixes #2018

## Bounty

- Label: bounty
- Type: bounty/coding
- Complexity: bounty/medium