### PR TITLE
fix: prevent double-stringification of AsyncAPI string in archiver service (#2026)

### DIFF
--- a/src/domains/services/archiver.service.ts
+++ b/src/domains/services/archiver.service.ts
@@ -27,10 +27,11 @@ export class ArchiverService {
 
   public appendAsyncAPIDocument(
     archive: Archiver,
-    asyncapi: string,
+    asyncapi: string | object,
     fileName = 'asyncapi',
   ) {
-    asyncapi = JSON.stringify(asyncapi);
+    const content =
+      typeof asyncapi === 'string' ? asyncapi : JSON.stringify(asyncapi);
     const language = retrieveLangauge(asyncapi);
     if (language === 'yaml') {
       archive.append(asyncapi, { name: `${fileName}.yml` });


### PR DESCRIPTION
## Summary

In `src/domains/services/archiver.service.ts`, the `appendAsyncAPIDocument` method always called `JSON.stringify(asyncapi)` even when `asyncapi` was already a string. This caused valid AsyncAPI YAML/JSON strings to be double-serialized, resulting in invalid documents in the generated zip archive.

## Fix

Changed `appendAsyncAPIDocument` to only stringify when the input is an object:
```typescript
const content =
  typeof asyncapi === 'string' ? asyncapi : JSON.stringify(asyncapi);
```

Also updated the method signature to accept `string | object` instead of just `string`.

## Related Issue

Fixes #2026