### PR TITLE
fix: correct broken link to git-workflow.md in DEVELOPMENT.md (#1962)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,7 +13,7 @@ git clone https://github.com/{your_username}/cli.git
 cd cli
 ```
 
-After cloning the repository, you should setup the fork properly and configure the `remote` repository as described [here](https://github.com/asyncapi/community/blob/master/git-workflow.md)
+After cloning the repository, you should setup the fork properly and configure the `remote` repository as described [here](https://github.com/asyncapi/community/blob/master/docs/010-contribution-guidelines/git-workflow.md)
 
 2. Install dependencies:
 


### PR DESCRIPTION
## Summary

The `[here]` link in DEVELOPMENT.md pointing to the AsyncAPI Git workflow was broken (404).

Old link: `https://github.com/asyncapi/community/blob/master/git-workflow.md`
New link: `https://github.com/asyncapi/community/blob/master/docs/010-contribution-guidelines/git-workflow.md`

## Related Issue

Fixes #1962