### PR TITLE
fix: GitHub URL parsing and file extension detection for issue #1940

### DIFF
--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -237,7 +237,8 @@ export async function fileExists(name: string): Promise<boolean> {
       return true;
     }
 
-    const extension = name.split('.')[1];
+    // Use path.extname to correctly handle files with multiple dots (e.g., my.asyncapi.yaml)
+    const extension = path.extname(name).slice(1);
 
     const allowedExtenstion = ['yml', 'yaml', 'json'];
 

--- a/src/domains/services/validation.service.ts
+++ b/src/domains/services/validation.service.ts
@@ -69,8 +69,9 @@ const convertGitHubWebUrl = (url: string): string => {
   const urlWithoutFragment = url.split('#')[0];
 
   // Handle GitHub web URLs like: https://github.com/owner/repo/blob/branch/path
+  // Note: branch name can contain slashes (e.g., feature/new-validation)
   // eslint-disable-next-line no-useless-escape
-  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/;
+  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/(.+)\/([^\/]+)$/;
   const match = urlWithoutFragment.match(githubWebPattern);
 
   if (match) {


### PR DESCRIPTION
## Description

This PR fixes two bugs reported in issue #1940:

### Bug 1: GitHub URL Parsing with Slash-based Branch Names

**Problem:** The CLI failed to parse GitHub URLs when branch names contained slashes (e.g., `feature/new-validation`).

**Root Cause:** The regex pattern assumed branch names do not contain `/`:
```typescript
const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/;
//                                                                ^^^^^^^^
//                                                                Only matches non-slash characters
```

**Fix:** Updated the regex to capture the entire branch path (including slashes):
```typescript
const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/(.+)\/([^\/]+)$/;
//                                                                ^^^^
//                                                                Matches any characters (including slashes)
```

### Bug 2: File Extension Detection for Multi-dot Filenames

**Problem:** Files with multiple dots in the name (e.g., `my.asyncapi.yaml`) were incorrectly parsed.

**Root Cause:** Using `name.split('.')[1]` returns the second segment, not the extension:
```javascript
'my.asyncapi.yaml'.split('.') // ['my', 'asyncapi', 'yaml']
//                               [1] = 'asyncapi' (WRONG!)
```

**Fix:** Use `path.extname()` which correctly handles multi-dot filenames:
```typescript
const extension = path.extname(name).slice(1); // 'yaml' ✅
```

## Testing

Both fixes have been tested with multiple test cases:

### GitHub URL Parsing Tests
- ✅ `https://github.com/org/repo/blob/feature/new-validation/spec.yaml`
- ✅ `https://github.com/org/repo/blob/main/spec.yaml`
- ✅ `https://github.com/org/repo/blob/feature/branch/name/spec.yaml`

### File Extension Tests
- ✅ `asyncapi.yaml` → `yaml`
- ✅ `my.asyncapi.yaml` → `yaml`
- ✅ `test.v2.asyncapi.yaml` → `yaml`
- ✅ `file.with.many.dots.json` → `json`

## Related Issue

Closes #1940