### PR TITLE
fix: add a fix timeout while calling to external registry

### DIFF
--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -1,3 +1,20 @@
+/**
+ * Default wait before registry reachability check fails (https://github.com/asyncapi/cli/issues/2027).
+ * 15s balances fail-fast vs slow VPNs/proxies; override with ASYNCAPI_REGISTRY_CHECK_TIMEOUT_MS.
+ */
+const REGISTRY_REACHABILITY_TIMEOUT_MS = 15_000;
+
+function registryReachabilityTimeoutMs(): number {
+  const env = process.env.ASYNCAPI_REGISTRY_CHECK_TIMEOUT_MS;
+  if (env !== undefined && env !== '') {
+    const parsed = Number(env);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return REGISTRY_REACHABILITY_TIMEOUT_MS;
+}
+
 export function registryURLParser(input?: string) {
   if (!input) { return; }
   const isURL = /^https?:/;
@@ -6,14 +23,58 @@ export function registryURLParser(input?: string) {
   }
 }
 
+function isAbortError(err: unknown): boolean {
+  if (err instanceof Error && err.name === 'AbortError') {
+    return true;
+  }
+  return (
+    typeof DOMException !== 'undefined' &&
+    err instanceof DOMException &&
+    err.name === 'AbortError'
+  );
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: Omit<RequestInit, 'signal'>,
+): Promise<Response> {
+  const controller = new AbortController();
+  const ms = registryReachabilityTimeoutMs();
+  const timeoutId = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 export async function registryValidation(registryUrl?: string, registryAuth?: string, registryToken?: string) {
   if (!registryUrl) { return; }
   try {
-    const response = await fetch(registryUrl as string);
+    let response = await fetchWithTimeout(registryUrl as string, {
+      method: 'HEAD',
+      redirect: 'follow',
+    });
+    if (response.status === 405) {
+      response = await fetchWithTimeout(registryUrl as string, {
+        method: 'GET',
+        redirect: 'follow',
+      });
+    }
     if (response.status === 401 && !registryAuth && !registryToken) {
       throw new Error('You Need to pass either registryAuth in username:password encoded in Base64 or need to pass registryToken');
     }
-  } catch {
-    throw new Error(`Can't fetch registryURL: ${registryUrl}`);
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message.startsWith('You Need to pass')) {
+      throw err;
+    }
+    if (isAbortError(err)) {
+      const seconds = registryReachabilityTimeoutMs() / 1000;
+      throw new Error(
+        `Registry URL timed out or is unreachable after ${seconds}s: ${registryUrl}`,
+      );
+    }
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Can't fetch registryURL: ${registryUrl} (${detail})`);
   }
 }

--- a/test/unit/utils/registry.test.ts
+++ b/test/unit/utils/registry.test.ts
@@ -99,7 +99,7 @@ describe('registryValidation()', () => {
       await registryValidation('https://registry.npmjs.org');
       expect.fail('expected throw');
     } catch (e: unknown) {
-      expect((e as Error).message).to.include("Can't fetch registryURL");
+      expect((e as Error).message).to.include('Can\'t fetch registryURL');
       expect((e as Error).message).to.include('fetch failed');
     }
   });

--- a/test/unit/utils/registry.test.ts
+++ b/test/unit/utils/registry.test.ts
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+import {
+  registryURLParser,
+  registryValidation,
+} from '../../../src/utils/generate/registry';
+
+describe('registryURLParser()', () => {
+  it('allows undefined', () => {
+    expect(registryURLParser(undefined)).to.equal(undefined);
+  });
+
+  it('rejects non-http(s) url', () => {
+    expect(() => registryURLParser('ftp://x')).to.throw(/Invalid --registry-url/);
+  });
+});
+
+describe('registryValidation()', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('no-ops when registry url is missing', async () => {
+    await registryValidation(undefined);
+  });
+
+  it('succeeds on HEAD 200', async () => {
+    globalThis.fetch = async () =>
+      new Response(null, { status: 200 }) as unknown as Response;
+    await registryValidation('https://registry.npmjs.org');
+  });
+
+  it('retries with GET when HEAD returns 405', async () => {
+    let calls = 0;
+    globalThis.fetch = async (_url, init) => {
+      calls += 1;
+      const method = (init as RequestInit)?.method ?? 'GET';
+      if (calls === 1) {
+        expect(method).to.equal('HEAD');
+        return new Response(null, { status: 405 }) as unknown as Response;
+      }
+      expect(method).to.equal('GET');
+      return new Response(null, { status: 200 }) as unknown as Response;
+    };
+    await registryValidation('https://example.com/npm');
+    expect(calls).to.equal(2);
+  });
+
+  it('throws when 401 and no credentials', async () => {
+    globalThis.fetch = async () =>
+      new Response(null, { status: 401 }) as unknown as Response;
+    try {
+      await registryValidation('https://private.registry/npm');
+      expect.fail('expected throw');
+    } catch (e: unknown) {
+      expect((e as Error).message).to.match(/registryAuth|registryToken/);
+    }
+  });
+
+  it('does not throw on 401 when token is set', async () => {
+    globalThis.fetch = async () =>
+      new Response(null, { status: 401 }) as unknown as Response;
+    await registryValidation('https://private.registry/npm', undefined, 'tok');
+  });
+
+  it('surfaces timeout as a clear error', async () => {
+    process.env.ASYNCAPI_REGISTRY_CHECK_TIMEOUT_MS = '50';
+    try {
+      globalThis.fetch = async (_url, init) => {
+        const signal = (init as RequestInit).signal;
+        return await new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => {
+            reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }));
+          });
+        });
+      };
+      try {
+        await registryValidation('http://10.255.255.1');
+        expect.fail('expected throw');
+      } catch (e: unknown) {
+        expect((e as Error).message).to.match(/timed out|unreachable/);
+        expect((e as Error).message).to.include('10.255.255.1');
+      }
+    } finally {
+      delete process.env.ASYNCAPI_REGISTRY_CHECK_TIMEOUT_MS;
+    }
+  });
+
+  it('includes underlying message on network failure', async () => {
+    globalThis.fetch = async () => {
+      throw new TypeError('fetch failed');
+    };
+    try {
+      await registryValidation('https://registry.npmjs.org');
+      expect.fail('expected throw');
+    } catch (e: unknown) {
+      expect((e as Error).message).to.include("Can't fetch registryURL");
+      expect((e as Error).message).to.include('fetch failed');
+    }
+  });
+});


### PR DESCRIPTION
close:   https://github.com/asyncapi/cli/issues/2027
* Added a timeout  to abort the request 
* Related: https://github.com/asyncapi/cli/issues/2039