### PR TITLE
fix: add 10s timeout and HEAD request to registry validation (#2027)

### DIFF
--- a/.changeset/fix-registry-timeout.md
+++ b/.changeset/fix-registry-timeout.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Fix bug where the CLI would hang indefinitely when the registry URL was unreachable. Added a 10s timeout and optimized validation using HEAD requests.

--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -8,12 +8,22 @@ export function registryURLParser(input?: string) {
 
 export async function registryValidation(registryUrl?: string, registryAuth?: string, registryToken?: string) {
   if (!registryUrl) { return; }
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
   try {
-    const response = await fetch(registryUrl as string);
+    const response = await fetch(registryUrl as string, {
+      method: 'HEAD',
+      signal: controller.signal
+    });
+    clearTimeout(timeoutId);
     if (response.status === 401 && !registryAuth && !registryToken) {
       throw new Error('You Need to pass either registryAuth in username:password encoded in Base64 or need to pass registryToken');
     }
-  } catch {
-    throw new Error(`Can't fetch registryURL: ${registryUrl}`);
+  } catch (err: any) {
+    clearTimeout(timeoutId);
+    if (err.name === 'AbortError') {
+      throw new Error(`Timeout: Can't fetch registryURL within 10s: ${registryUrl}`);
+    }
+    throw new Error(`Can't fetch registryURL: ${registryUrl}. ${err.message || ''}`);
   }
 }


### PR DESCRIPTION
Fix [BUG] CLI hangs indefinitely when --registry-url points to an unreachable host (#2027). 

/claim #2027