### PR TITLE
fix: resolve $ref for external files (#1839)

### DIFF
--- a/.changeset/fix-ref-resolution.md
+++ b/.changeset/fix-ref-resolution.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Fix bug where external files in the same directory were not correctly resolved via `$ref`.

--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -81,12 +81,13 @@ export class Specification {
 
   static async fromFile(filepath: string) {
     let spec;
+    const absolutePath = path.resolve(process.cwd(), filepath);
     try {
-      spec = await readFile(filepath, { encoding: 'utf8' });
+      spec = await readFile(absolutePath, { encoding: 'utf8' });
     } catch {
-      throw new ErrorLoadingSpec('file', filepath);
+      throw new ErrorLoadingSpec('file', absolutePath);
     }
-    return new Specification(spec, { filepath });
+    return new Specification(spec, { filepath: absolutePath });
   }
 
   static async fromURL(URLpath: string) {

--- a/src/domains/services/generator.service.ts
+++ b/src/domains/services/generator.service.ts
@@ -109,7 +109,7 @@ export class GeneratorService extends BaseService {
     try {
       await generator.generateFromString(asyncapi.text(), {
         ...genOption,
-        path: asyncapi,
+        path: asyncapi.getSource(),
       });
     } catch (err: unknown) {
       s.stop('Generation failed');


### PR DESCRIPTION
Fix [BUG] external files in same directory are not resolved via $ref since v3.3.0 (#1839). 

/claim #1839