### PR TITLE
fix: support slash-based branches and multi-dot filenames in URL parsing

### DIFF
--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -237,7 +237,7 @@ export async function fileExists(name: string): Promise<boolean> {
       return true;
     }
 
-    const extension = name.split('.')[1];
+    const extension = name.includes('.') ? name.split('.').pop() : '';
 
     const allowedExtenstion = ['yml', 'yaml', 'json'];
 

--- a/src/domains/services/validation.service.ts
+++ b/src/domains/services/validation.service.ts
@@ -70,7 +70,7 @@ const convertGitHubWebUrl = (url: string): string => {
 
   // Handle GitHub web URLs like: https://github.com/owner/repo/blob/branch/path
   // eslint-disable-next-line no-useless-escape
-  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/;
+  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/(.+)\/(.+)$/;
   const match = urlWithoutFragment.match(githubWebPattern);
 
   if (match) {


### PR DESCRIPTION
Fixes #1940

## Changes

### 1. GitHub URL Parsing - Support slash-based branches
- Changed regex from `([^\/]+)` to `(.+)` for branch name matching
- Now correctly handles branches like `feature/new-validation`

### 2. File Extension Detection - Support multi-dot filenames
- Changed `name.split('.')[1]` to `name.includes('.') ? name.split('.').pop() : ''`
- Now correctly handles filenames like `my.asyncapi.yaml` (returns `yaml` instead of `asyncapi`)
- Gracefully handles files without extensions

## Testing
- URLs like `https://github.com/org/repo/blob/feature/new-validation/spec.yaml` now parse correctly
- Filenames like `my.asyncapi.yaml` now detect extension as `yaml`
- Filenames without extensions no longer crash