### PR TITLE
fix: handle empty AsyncAPI files gracefully (fixes #1993)

### DIFF
--- a/.changeset/fix-empty-file-crash.md
+++ b/.changeset/fix-empty-file-crash.md
@@ -1,0 +1,7 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: handle empty AsyncAPI files gracefully
+
+When an empty file is provided, the CLI now throws a clear ErrorLoadingSpec error instead of crashing with a raw TypeError.

--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -86,6 +86,9 @@ export class Specification {
     } catch {
       throw new ErrorLoadingSpec('file', filepath);
     }
+    if (!spec || spec.trim().length === 0) {
+      throw new ErrorLoadingSpec('empty-file', filepath);
+    }
     return new Specification(spec, { filepath });
   }
 

--- a/src/errors/specification-file.ts
+++ b/src/errors/specification-file.ts
@@ -31,7 +31,7 @@ export class SpecificationURLNotFound extends SpecificationFileError {
   }
 }
 
-type From = 'file' | 'url' | 'context' | 'invalid file';
+type From = 'file' | 'url' | 'context' | 'invalid file' | 'empty-file';
 
 export class ErrorLoadingSpec extends Error {
   private readonly errorMessages = {
@@ -54,6 +54,10 @@ export class ErrorLoadingSpec extends Error {
     if (from === 'invalid file') {
       this.name = 'Invalid AsyncAPI file type';
       this.message = 'cli only supports yml ,yaml ,json extension';
+    }
+    if (from === 'empty-file') {
+      this.name = 'Empty AsyncAPI file';
+      this.message = `The provided AsyncAPI file ${param} is empty. Please provide a valid AsyncAPI document.`;
     }
 
     if (!from) {

--- a/test/unit/models/specification-file.test.ts
+++ b/test/unit/models/specification-file.test.ts
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { Specification, load } from '../../../src/domains/models/SpecificationFile';
+import { ErrorLoadingSpec } from '../../../src/errors/specification-file';
+
+const { writeFile, unlink, mkdir } = fs;
+
+const TMP_DIR = path.join(__dirname, '../../fixtures/tmp');
+
+describe('SpecificationFile', () => {
+  before(async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+  });
+
+  after(async () => {
+    try {
+      await unlink(path.join(TMP_DIR, 'empty.yaml'));
+    } catch {
+      // ignore
+    }
+    try {
+      await unlink(path.join(TMP_DIR, 'empty.json'));
+    } catch {
+      // ignore
+    }
+    try {
+      await unlink(path.join(TMP_DIR, 'whitespace-only.yaml'));
+    } catch {
+      // ignore
+    }
+  });
+
+  describe('fromFile', () => {
+    it('should throw ErrorLoadingSpec for empty YAML file', async () => {
+      const emptyFile = path.join(TMP_DIR, 'empty.yaml');
+      await writeFile(emptyFile, '', 'utf8');
+
+      try {
+        await Specification.fromFile(emptyFile);
+        expect.fail('Should have thrown ErrorLoadingSpec');
+      } catch (error) {
+        expect(error).to.be.instanceOf(ErrorLoadingSpec);
+        expect(error.message).to.include('empty');
+      }
+    });
+
+    it('should throw ErrorLoadingSpec for empty JSON file', async () => {
+      const emptyFile = path.join(TMP_DIR, 'empty.json');
+      await writeFile(emptyFile, '', 'utf8');
+
+      try {
+        await Specification.fromFile(emptyFile);
+        expect.fail('Should have thrown ErrorLoadingSpec');
+      } catch (error) {
+        expect(error).to.be.instanceOf(ErrorLoadingSpec);
+        expect(error.message).to.include('empty');
+      }
+    });
+
+    it('should throw ErrorLoadingSpec for whitespace-only file', async () => {
+      const whitespaceFile = path.join(TMP_DIR, 'whitespace-only.yaml');
+      await writeFile(whitespaceFile, '   \n  \n  ', 'utf8');
+
+      try {
+        await Specification.fromFile(whitespaceFile);
+        expect.fail('Should have thrown ErrorLoadingSpec');
+      } catch (error) {
+        expect(error).to.be.instanceOf(ErrorLoadingSpec);
+        expect(error.message).to.include('empty');
+      }
+    });
+
+    it('should load valid YAML file successfully', async () => {
+      const validFile = path.join(__dirname, '../../fixtures/specification.yml');
+      const spec = await Specification.fromFile(validFile);
+      expect(spec).to.be.instanceOf(Specification);
+      expect(spec.text()).to.include('asyncapi');
+    });
+  });
+});


### PR DESCRIPTION
## What

When an empty file is provided to the CLI, it now throws a clear `ErrorLoadingSpec` error instead of crashing with a raw TypeError.

## Why

Previously, empty files caused a crash because `yaml.load('')` returns `undefined`, and the code tried to access `.asyncapi.startsWith()` on it. This resulted in an unhelpful JavaScript TypeError for the user.

## How

- Added empty file check in `Specification.fromFile()` before returning the Specification object
- Added new `'empty-file'` error type in `ErrorLoadingSpec` with a user-friendly message
- Added unit tests for empty YAML, empty JSON, and whitespace-only files

## Changes

| File | Change |
|------|--------|
| `src/domains/models/SpecificationFile.ts` | Add empty file check in `fromFile()` |
| `src/errors/specification-file.ts` | Add `'empty-file'` error type to `From` union and constructor |
| `test/unit/models/specification-file.test.ts` | NEW: 4 tests for empty file handling |

## Testing

```bash
# Test with empty file
touch empty.yaml
asyncapi generate fromTemplate empty.yaml ./test-template -o out
# Expected: "The provided AsyncAPI file empty.yaml is empty. Please provide a valid AsyncAPI document."
# Previously: TypeError: Cannot read properties of undefined (reading 'startsWith')
```

Fixes #1993
