### PR TITLE
fix: remove duplicate AsyncAPI spec loading in fromTemplate command (fixes #2017)

### DIFF
--- a/.changeset/fix-duplicate-loading.md
+++ b/.changeset/fix-duplicate-loading.md
@@ -1,0 +1,7 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: remove duplicate AsyncAPI spec loading in fromTemplate command
+
+The fromTemplate command was loading the AsyncAPI file twice. Reuse the result from loadAsyncAPIInput() instead of loading again.

--- a/src/apps/cli/commands/generate/fromTemplate.ts
+++ b/src/apps/cli/commands/generate/fromTemplate.ts
@@ -1,7 +1,6 @@
 import { Args } from '@oclif/core';
 import { BaseGeneratorCommand } from '@cli/internal/base/BaseGeneratorCommand';
-import { load, Specification } from '@models/SpecificationFile';
-import { ValidationError } from '@errors/validation-error';
+import { Specification } from '@models/SpecificationFile';
 import { GeneratorError } from '@errors/generator-error';
 import { intro } from '@clack/prompts';
 import { inverse } from 'picocolors';
@@ -65,19 +64,7 @@ export default class Template extends BaseGeneratorCommand {
     const watchTemplate = flags['watch'];
     const genOption = this.buildGenOption(flags, parsedFlags);
 
-    let specification: Specification;
-    try {
-      specification = await load(asyncapi);
-    } catch {
-      return this.error(
-        new ValidationError({
-           
-          type: 'invalid-file',
-          filepath: asyncapi,
-        }),
-        { exit: 1 },
-      );
-    }
+    const specification = asyncapiInput;
 
     const result = await this.generatorService.generate(
       specification,


### PR DESCRIPTION
## What

Remove duplicate AsyncAPI specification loading in the `fromTemplate` command.

## Why

The `fromTemplate` command was loading the AsyncAPI file twice during execution:

1. Via `this.loadAsyncAPIInput(asyncapi)` on line 60
2. Via `load(asyncapi)` on line 70

This caused:
- Duplicate disk I/O
- Duplicate parsing
- Unnecessary memory usage
- Slower execution for large specifications

## How

- Reuse the result from `loadAsyncAPIInput()` instead of calling `load()` again
- Remove unused imports (`load`, `ValidationError`)
- The `loadAsyncAPIInput()` method already handles error cases internally

## Changes

| File | Change |
|------|--------|
| `src/apps/cli/commands/generate/fromTemplate.ts` | Reuse `asyncapiInput` for `specification`, remove duplicate `load()` call and unused imports |

## Testing

The command should work exactly as before, but faster for large spec files:

```bash
# Before: loads file twice
asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template -o ./docs

# After: loads file once
asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template -o ./docs
```

Fixes #2017
