### PR TITLE
fix: detect multi-document YAML and show clear error message (fixes #1997)

### DIFF
--- a/.changeset/fix-multi-doc-yaml.md
+++ b/.changeset/fix-multi-doc-yaml.md
@@ -1,0 +1,7 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: detect multi-document YAML and show clear error message
+
+When an AsyncAPI file contains multiple YAML documents (separated by ---), the CLI now throws a clear error instead of falling into an incorrect parsing code path.

--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -45,6 +45,14 @@ export class Specification {
   }
 
   toJson(): Record<string, any> {
+    // Check for multi-document YAML (contains --- separator)
+    const trimmed = this.spec.trim();
+    if (trimmed.includes('\n---\n') || trimmed.startsWith('---\n')) {
+      throw new Error(
+        'The provided AsyncAPI file contains multiple YAML documents (separated by ---). ' +
+        'AsyncAPI supports only a single document per file. Please remove the extra document separators.'
+      );
+    }
     try {
       return yaml.load(this.spec, { json: true }) as Record<string, any>;
     } catch {


### PR DESCRIPTION
## What

Detect multi-document YAML files and show a clear error message instead of falling into an incorrect parsing code path.

## Why

When an AsyncAPI file contains multiple YAML documents (separated by `---`), the CLI fails with a low-level and misleading parser error. While AsyncAPI supports only a single document, multi-document YAML is valid YAML and commonly appears in real-world workflows. The CLI should fail explicitly and clearly.

## How

- Added a check in `Specification.toJson()` for multi-document YAML (presence of `---` separator)
- When detected, throw a clear error message explaining the issue and how to fix it
- The check happens before `yaml.load()` to prevent misleading parser errors

## Changes

| File | Change |
|------|--------|
| `src/domains/models/SpecificationFile.ts` | Add multi-document YAML detection in `toJson()` |

## Testing

```bash
# Create multi-document YAML
cat > multi-doc.yaml <<EOF
asyncapi: 3.0.0
info:
  title: Test
  version: 1.0.0
---
asyncapi: 3.0.0
info:
  title: Test 2
  version: 1.0.0
EOF

# Before: misleading parser error
asyncapi validate multi-doc.yaml

# After: clear error message
# "The provided AsyncAPI file contains multiple YAML documents (separated by ---). AsyncAPI supports only a single document per file. Please remove the extra document separators."
```

Fixes #1997
