### PR TITLE
fix: add empty args definition to versions command (fixes #2021)

### DIFF
--- a/.changeset/fix-unparsed-command-warnings.md
+++ b/.changeset/fix-unparsed-command-warnings.md
@@ -1,0 +1,7 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: add empty args definition to versions command
+
+The versions command was missing the static args definition, which caused oclif to emit UnparsedCommand warnings during test runs.

--- a/src/apps/cli/commands/config/versions.ts
+++ b/src/apps/cli/commands/config/versions.ts
@@ -7,6 +7,8 @@ export default class Versions extends Command {
 
   static flags = helpFlag();
 
+  static args = {};
+
   async run() {
     const dependencies: string[] = [];
     let dependency = '';

--- a/src/apps/cli/commands/config/versions.ts
+++ b/src/apps/cli/commands/config/versions.ts
@@ -7,7 +7,7 @@ export default class Versions extends Command {
 
   static flags = helpFlag();
 
-  static args = {};
+  static readonly args = {};
 
   async run() {
     const dependencies: string[] = [];


### PR DESCRIPTION
## What

Add empty `args` definition to the `versions` command to prevent `UnparsedCommand` warnings during test runs.

## Why

The `versions` command was missing the `static args` definition, which caused oclif to emit `UnparsedCommand` warnings during test runs. This is a common pattern in oclif commands - all commands should have explicit `args` definitions even if they don't accept arguments.

## How

- Added `static args = {};` to the `Versions` command class
- This follows the pattern used by other commands in the codebase

## Changes

| File | Change |
|------|--------|
| `src/apps/cli/commands/config/versions.ts` | Add `static args = {}` definition |

## Testing

```bash
# Before: shows UnparsedCommand warning
npm run cli:test 2>&1 | grep -i "unparsed"

# After: no warning
npm run cli:test 2>&1 | grep -i "unparsed"
```

Fixes #2021
