### PR TITLE
fix: skip metrics submission after fatal generation failure (fixes #2010)

### DIFF
--- a/.changeset/fix-metrics-after-failure.md
+++ b/.changeset/fix-metrics-after-failure.md
@@ -1,0 +1,7 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: skip metrics submission after fatal generation failure
+
+When a generation fails with a fatal error, the CLI was still attempting to submit anonymous metrics. Now metrics are only submitted when there's no error.

--- a/src/apps/cli/internal/base.ts
+++ b/src/apps/cli/internal/base.ts
@@ -114,12 +114,15 @@ export default abstract class extends Command {
   }
   async finally(error: Error | undefined): Promise<any> {
     await super.finally(error);
-    this.metricsMetadata['success'] = error === undefined;
-    await this.recordActionFinished(
-      this.id as string,
-      this.metricsMetadata,
-      this.specFile?.text(),
-    );
+    // Only submit metrics when there's no fatal error
+    if (error === undefined) {
+      this.metricsMetadata['success'] = true;
+      await this.recordActionFinished(
+        this.id as string,
+        this.metricsMetadata,
+        this.specFile?.text(),
+      );
+    }
   }
 
   async recorderFromEnv(prefix: string): Promise<Recorder> {


### PR DESCRIPTION
## What

Skip anonymous metrics submission after a fatal generation failure.

## Why

When a generation fails with a fatal error (e.g., non-empty output directory), the CLI was still attempting to submit anonymous metrics in the `finally()` method. This resulted in additional unrelated errors being printed, which polluted the output and confused users.

## How

- Modified the `finally()` method in the base command to only submit metrics when there's no error
- When there's an error, the method now skips metrics submission entirely
- This prevents secondary errors from being printed after a fatal failure

## Changes

| File | Change |
|------|--------|
| `src/apps/cli/internal/base.ts` | Skip metrics submission in `finally()` when error is present |

## Testing

```bash
# Before: prints metrics error after generation failure
mkdir out && echo test > out/file.txt
asyncapi generate asyncapi.yaml @asyncapi/html-template --output ./out
# Shows: generation error + metrics submission error

# After: only prints generation failure
asyncapi generate asyncapi.yaml @asyncapi/html-template --output ./out
# Shows: only generation error
```

Fixes #2010
