### PR TITLE
fix: skip redundant AsyncAPI examples fetching during build (fixes #2015)

### DIFF
--- a/.changeset/fix-skip-redundant-fetch.md
+++ b/.changeset/fix-skip-redundant-fetch.md
@@ -1,0 +1,7 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: skip redundant AsyncAPI examples fetching during build
+
+The fetch-asyncapi-example.js script was running on every build, even when examples already existed. Now it checks if examples.json exists before fetching.

--- a/scripts/fetch-asyncapi-example.js
+++ b/scripts/fetch-asyncapi-example.js
@@ -115,10 +115,22 @@ const listAllProtocolsForFile = (document) => {
 };
 
 const tidyUp = async () => {
-  fs.unlinkSync(TEMP_ZIP_NAME);
+  if (fs.existsSync(TEMP_ZIP_NAME)) {
+    fs.unlinkSync(TEMP_ZIP_NAME);
+  }
+};
+
+const examplesAlreadyExist = () => {
+  const examplesJsonPath = path.join(EXAMPLE_DIRECTORY, 'examples.json');
+  return fs.existsSync(examplesJsonPath) && fs.existsSync(EXAMPLE_DIRECTORY);
 };
 
 (async () => {
+  if (examplesAlreadyExist()) {
+    console.log('Examples already exist, skipping fetch. Delete assets/examples/ to force re-fetch.');
+    return;
+  }
+
   await fetchAsyncAPIExamplesFromExternalURL();
   await unzipAsyncAPIExamples();
   await buildCLIListFromExamples();


### PR DESCRIPTION
## What

Skip redundant AsyncAPI examples fetching during build when examples already exist.

## Why

The `scripts/fetch-asyncapi-example.js` script was running on every build, even when examples already existed. This caused:
- Slower build times (downloading ZIP + parsing YAML files)
- Unnecessary network traffic
- Flaky builds when GitHub is unreachable

## How

- Added a check to see if `assets/examples/examples.json` already exists
- If it does, skip the entire fetch/unzip/parse workflow
- To force a re-fetch, delete the `assets/examples/` directory
- Also made `tidyUp()` safe by checking if the ZIP file exists before deleting

## Changes

| File | Change |
|------|--------|
| `scripts/fetch-asyncapi-example.js` | Add existence check before fetching examples |

## Testing

```bash
# First build: fetches examples
npm run build

# Second build: skips fetch (fast)
npm run build
# Output: "Examples already exist, skipping fetch. Delete assets/examples/ to force re-fetch."

# Force re-fetch
rm -rf assets/examples/
npm run build
```

Fixes #2015
