### PR TITLE
fix: preserve error chain in registry validation (fixes #2013)

### DIFF
--- a/.changeset/fix-registry-error-details.md
+++ b/.changeset/fix-registry-error-details.md
@@ -1,0 +1,7 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: preserve error chain in registry validation
+
+When registry validation fails, the original error is now preserved as the cause property, making it easier to debug network, DNS, SSL, and proxy issues.

--- a/src/utils/generate/registry.ts
+++ b/src/utils/generate/registry.ts
@@ -75,6 +75,10 @@ export async function registryValidation(registryUrl?: string, registryAuth?: st
       );
     }
     const detail = err instanceof Error ? err.message : String(err);
-    throw new Error(`Can't fetch registryURL: ${registryUrl} (${detail})`);
+    const wrappedError = new Error(`Can't fetch registryURL: ${registryUrl} (${detail})`);
+    if (err instanceof Error) {
+      wrappedError.cause = err;
+    }
+    throw wrappedError;
   }
 }


### PR DESCRIPTION
## What

Preserve the error chain in registry validation so users can see the full cause of failures.

## Why

When registry validation fails, the original error was included in the message text but the error chain (`cause` property) was lost. This made it difficult to debug issues like:
- Network timeouts
- DNS failures
- SSL errors
- Proxy issues

## How

- Wrapped the original error as the `cause` property of the new error
- This preserves the full error chain for debugging
- The error message still includes the detail for backward compatibility

## Changes

| File | Change |
|------|--------|
| `src/utils/generate/registry.ts` | Preserve error chain using `cause` property |

## Testing

```bash
# Test with invalid registry URL
asyncapi generate asyncapi.yaml @asyncapi/html-template --registry-url https://invalid.example.com
# Error now shows: "Can't fetch registryURL: https://invalid.example.com (...)"
# With cause chain preserved for debugging
```

Fixes #2013
