### PR TITLE
fix: limit diagnostics-format options to actually supported formats (fixes #2007)

### DIFF
--- a/src/apps/cli/internal/flags/parser.flags.ts
+++ b/src/apps/cli/internal/flags/parser.flags.ts
@@ -1,5 +1,4 @@
 import { Flags } from '@oclif/core';
-import { OutputFormat } from '@stoplight/spectral-cli/dist/services/config';
 
 export interface ValidationFlagsOptions {
   logDiagnostics?: boolean;
@@ -16,8 +15,8 @@ export function parserFlags({
     }),
     'diagnostics-format': Flags.option({
       description: 'format to use for validation diagnostics',
-      options: Object.values(OutputFormat),
-      default: OutputFormat.STYLISH,
+      options: ['stylish', 'json', 'junit', 'html', 'text', 'teamcity', 'pretty'] as const,
+      default: 'stylish',
     })(),
     'fail-severity': Flags.option({
       description:


### PR DESCRIPTION
## What

Limit `--diagnostics-format` options to only the actually supported formats.

## Why

The help message showed 12 formats but only 7 were actually supported. The unsupported formats (`github-actions`, `sarif`, `code-climate`, `gitlab`, `markdown`) would silently fall back to `stylish` format, which was confusing for users.

## How

- Changed the `diagnostics-format` flag options from `Object.values(OutputFormat)` to a hardcoded list of the 7 supported formats
- Removed the unused `OutputFormat` import

## Changes

| File | Change |
|------|--------|
| `src/apps/cli/internal/flags/parser.flags.ts` | Limit options to supported formats, remove unused import |

## Testing

```bash
# Before: shows 12 options in help
asyncapi validate --help

# After: shows only 7 supported options
asyncapi validate --help
# Options: stylish, json, junit, html, text, teamcity, pretty
```

Fixes #2007
