### PR TITLE
fix: update studio message when --no-browser flag is used (fixes #2001)

### DIFF
--- a/src/domains/models/Studio.ts
+++ b/src/domains/models/Studio.ts
@@ -157,7 +157,11 @@ export function start(filePath: string, port: number = DEFAULT_PORT, noBrowser?:
       const listenPort = (addr && typeof addr === 'object' && 'port' in addr) ? (addr as any).port : port;
       const url = `http://localhost:${listenPort}?liveServer=${listenPort}&studio-version=${studioVersion}`;
       console.log(`🎉 Connected to Live Server running at ${blueBright(url)}.`);
-      console.log(`🌐 Open this URL in your web browser: ${blueBright(url)}`);
+      if (noBrowser) {
+        console.log(`🔗 Studio is running at ${blueBright(url)}`);
+      } else {
+        console.log(`🌐 Open this URL in your web browser: ${blueBright(url)}`);
+      }
       console.log(
         `🛑 If needed, press ${redBright('Ctrl + C')} to stop the process.`,
       );


### PR DESCRIPTION
## What

Update the studio output message when `--no-browser` flag is used.

## Why

When `--no-browser` flag is used, the message still showed "Open this URL in your web browser" which was confusing for users in remote environments (SSH, containers) or those who prefer to manually open the browser.

## How

- When `--no-browser` is used, show: "🔗 Studio is running at http://localhost:port"
- When default (browser opens), show: "🌐 Open this URL in your web browser: http://localhost:port"

## Changes

| File | Change |
|------|--------|
| `src/domains/models/Studio.ts` | Update output message based on `noBrowser` flag |

## Testing

```bash
# With --no-browser flag
asyncapi start studio --no-browser asyncapi.yaml
# Output: 🔗 Studio is running at http://localhost:3210

# Without flag (default)
asyncapi start studio asyncapi.yaml
# Output: 🌐 Open this URL in your web browser: http://localhost:3210
```

Fixes #2001
