### PR TITLE
fix: prevent double-stringification of AsyncAPI document in archiver (fixes #2026)

### DIFF
--- a/src/domains/services/archiver.service.ts
+++ b/src/domains/services/archiver.service.ts
@@ -27,15 +27,19 @@ export class ArchiverService {
 
   public appendAsyncAPIDocument(
     archive: Archiver,
-    asyncapi: string,
+    asyncapi: string | object,
     fileName = 'asyncapi',
   ) {
-    asyncapi = JSON.stringify(asyncapi);
-    const language = retrieveLangauge(asyncapi);
+    const content =
+      typeof asyncapi === 'string'
+        ? asyncapi
+        : JSON.stringify(asyncapi, null, 2);
+
+    const language = retrieveLangauge(content);
     if (language === 'yaml') {
-      archive.append(asyncapi, { name: `${fileName}.yml` });
+      archive.append(content, { name: `${fileName}.yml` });
     } else {
-      archive.append(asyncapi, { name: `${fileName}.json` });
+      archive.append(content, { name: `${fileName}.json` });
     }
   }
 


### PR DESCRIPTION
## What

Prevent double-stringification of AsyncAPI documents in the archiver service.

## Why

The `appendAsyncAPIDocument` method was always applying `JSON.stringify()` even when the input was already a string. This caused:
- YAML documents to be serialized as JSON string literals
- Newlines to be escaped (`\n`)
- The archived `asyncapi.yml` to contain a serialized string instead of a valid AsyncAPI document

## How

- Changed the method to only stringify when the input is an object
- Updated the type signature to accept `string | object`
- When input is a string, use it directly
- When input is an object, stringify with pretty-printing (`null, 2`)

## Changes

| File | Change |
|------|--------|
| `src/domains/services/archiver.service.ts` | Fix double-stringification, update type signature |

## Testing

```bash
# Before: archived file contains serialized string
asyncapi archive asyncapi.yaml
# asyncapi.yml contains: "\"asyncapi: 2.6.0\ninfo:\n  title: Example\n  version: 1.0.0\""

# After: archived file contains valid YAML
asyncapi archive asyncapi.yaml
# asyncapi.yml contains: asyncapi: 2.6.0\ninfo:\n  title: Example\n  version: 1.0.0
```

Fixes #2026
