### PR TITLE
fix: handle circular references in diff command gracefully (fixes #2093)

### DIFF
--- a/src/apps/cli/commands/diff.ts
+++ b/src/apps/cli/commands/diff.ts
@@ -132,9 +132,27 @@ export default class Diff extends Command {
         return;
       }
 
+      let firstJson: Record<string, any>;
+      let secondJson: Record<string, any>;
+
+      try {
+        firstJson = parsed.firstDocumentParsed.json();
+        secondJson = parsed.secondDocumentParsed.json();
+      } catch (jsonError) {
+        if (jsonError instanceof TypeError && jsonError.message.includes('circular')) {
+          this.error(
+            new Error(
+              'Cannot diff documents with circular references. ' +
+              'Please resolve the circular $ref references in your AsyncAPI documents before running diff.'
+            )
+          );
+        }
+        throw jsonError;
+      }
+
       const diffOutput = diff.diff(
-        parsed.firstDocumentParsed.json(),
-        parsed.secondDocumentParsed.json(),
+        firstJson,
+        secondJson,
         {
           override: overrides,
           outputType: outputFormat as diff.OutputType, // NOSONAR


### PR DESCRIPTION
## What

Handle circular references in the diff command gracefully instead of crashing.

## Why

When AsyncAPI documents contain circular `$ref` references, the `json()` method on parsed documents throws a `TypeError` with a message about circular structures. The diff command didn't handle this case, resulting in an unhelpful error for users.

## How

- Added a try-catch around the `json()` calls
- When a circular reference is detected (TypeError with 'circular' in message), show a clear error message
- The message guides users to resolve circular references before running diff

## Changes

| File | Change |
|------|--------|
| `src/apps/cli/commands/diff.ts` | Add error handling for circular references |

## Testing

```bash
# Create a file with circular reference
cat > circular.yaml <<EOF
asyncapi: 3.1.0
info:
  title: Testing
  version: 1.0.0
channels:
  my_entity_created:
    messages:
      entity-created:
        payload:
          \$ref: '#/components/schemas/entity-created'
components:
  schemas:
    entity-created:
      type: object
      properties:
        self:
          \$ref: '#/components/schemas/entity-created'
EOF

# Before: crashes with TypeError
asyncapi diff circular.yaml circular.yaml

# After: clear error message
# "Cannot diff documents with circular references. Please resolve the circular \$ref references in your AsyncAPI documents before running diff."
```

Fixes #2093
