### PR TITLE
test: add integration tests for optimize --output=overwrite (fixes #1933)

### DIFF
--- a/.changeset/optimize-overwrite-test.md
+++ b/.changeset/optimize-overwrite-test.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Add integration tests for optimize command with --output=overwrite flag

--- a/test/integration/optimize.test.ts
+++ b/test/integration/optimize.test.ts
@@ -12,6 +12,8 @@ const unoptimizedYamlFile = './test/fixtures/dummyspec/unoptimizedSpec.yml';
 const unoptimizedJsonFile = './test/fixtures/dummyspec/unoptimizedSpec.json';
 const invalidFile = './test/fixtures/specification-invalid.yml';
 const asyncapiv3 = './test/fixtures/specification-v3.yml';
+const tempOverwriteFile = './test/fixtures/dummyspec/unoptimizedSpec_copy.yml';
+const tempOverwriteJsonFile = './test/fixtures/dummyspec/unoptimizedSpec_copy.json';
 
 describe('optimize', () => {
   describe('no optimization needed', () => {
@@ -164,6 +166,38 @@ describe('optimize', () => {
         expect(ctx.stderr).to.equal('');
         expect(fs.readFileSync(optimizedFile, 'utf8')).to.contain('"asyncapi": "2.0.0"');
         fs.unlinkSync(optimizedFile);
+        done();
+      });
+
+    test
+      .stderr()
+      .stdout()
+      .do(() => {
+        fs.copySync(unoptimizedYamlFile, tempOverwriteFile);
+      })
+      .command(['optimize', tempOverwriteFile, '--no-tty', '-o', 'overwrite'])
+      .it('overwrite original file in place with --output=overwrite', (ctx, done) => {
+        expect(ctx.stdout).to.contain(`✅ Success! Your original file at ${tempOverwriteFile} has been updated.`);
+        expect(ctx.stderr).to.equal('');
+        const content = fs.readFileSync(tempOverwriteFile, 'utf8');
+        expect(content).to.contain('asyncapi: 2.0.0');
+        fs.unlinkSync(tempOverwriteFile);
+        done();
+      });
+
+    test
+      .stderr()
+      .stdout()
+      .do(() => {
+        fs.copySync(unoptimizedJsonFile, tempOverwriteJsonFile);
+      })
+      .command(['optimize', tempOverwriteJsonFile, '--no-tty', '-o', 'overwrite'])
+      .it('overwrite original JSON file in place with --output=overwrite', (ctx, done) => {
+        expect(ctx.stdout).to.contain(`✅ Success! Your original file at ${tempOverwriteJsonFile} has been updated.`);
+        expect(ctx.stderr).to.equal('');
+        const content = fs.readFileSync(tempOverwriteJsonFile, 'utf8');
+        expect(content).to.contain('"asyncapi": "2.0.0"');
+        fs.unlinkSync(tempOverwriteJsonFile);
         done();
       });
   });


### PR DESCRIPTION
## What does this PR do?

Adds missing integration test coverage for the `asyncapi optimize` command when using the `--output=overwrite` flag with `--no-tty` (fixes #1933)

## Changes

Added two new test cases to `test/integration/optimize.test.ts`:

1. **YAML overwrite test**: Copies an unoptimized YAML fixture to a temp file, runs `optimize --no-tty --output=overwrite`, verifies:
   - Output message confirms the original file was updated
   - The overwritten file still contains valid AsyncAPI content (`asyncapi: 2.0.0`)
   - No stderr errors

2. **JSON overwrite test**: Same flow with a JSON fixture, verifying JSON output format is preserved after overwrite

## Why this matters

The `--output=overwrite` path was previously untested, meaning regressions in file-overwriting behavior could go undetected.

## Related issue(s)

Fixes #1933

## Checklist

- [x] Tests added for `--output=overwrite` with YAML input
- [x] Tests added for `--output=overwrite` with JSON input  
- [x] Tests clean up temp files after running
- [x] Added changeset
