### PR TITLE
fix: suppress npm progress output in tests for hermeticity (fixes #2004)

### DIFF
--- a/.changeset/fix-test-hermeticity.md
+++ b/.changeset/fix-test-hermeticity.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Suppress npm progress output during tests to prevent stdout pollution (fixes #2004)

--- a/test/helpers/init.js
+++ b/test/helpers/init.js
@@ -2,6 +2,13 @@ const path = require('path');
 process.env.TS_NODE_PROJECT = path.resolve('test/tsconfig.json');
 process.env.NODE_ENV = 'development';
 
+// Suppress npm progress output during tests to prevent stdout pollution
+// (fixes #2004: integration tests fail when npm prints idealTree spinners)
+process.env.npm_config_loglevel = 'silent';
+process.env.npm_config_progress = 'false';
+process.env.NPM_CONFIG_LOGLEVEL = 'silent';
+process.env.NPM_CONFIG_PROGRESS = 'false';
+
 global.oclif = global.oclif || {};
 global.oclif.columns = 80;
 


### PR DESCRIPTION
## What does this PR do?

Makes integration tests hermetic by suppressing npm progress output that pollutes stdout and breaks assertions (fixes #2004)

## Problem

Integration tests fail because some CLI commands trigger real npm dependency resolution during test execution. npm prints progress output (idealTree spinners, dependency logs) to stdout, which breaks tests that assert exact empty or fixed string output.

## Solution

Added npm environment variables to `test/helpers/init.js`:
- `npm_config_loglevel=silent` — suppresses npm log output
- `npm_config_progress=false` — disables npm progress bars
- `NPM_CONFIG_LOGLEVEL=silent` — uppercase variant for broader compatibility
- `NPM_CONFIG_PROGRESS=false` — uppercase variant

This ensures all npm operations during tests run silently, preventing stdout pollution.

## Why this approach

- **Minimal change**: Only 6 lines added to a single file
- **No test rewrites needed**: Existing assertions work as-is
- **Environment-independent**: Works regardless of npm version, OS, or network conditions
- **Non-invasive**: Doesn't affect the CLI's behavior in production

## Related issue(s)

Fixes #2004

## Checklist

- [x] Added npm environment variables to test init
- [x] Added changeset
- [x] No changes to CLI behavior
