### PR TITLE
fix: add format hint to --param flag description (fixes #1977)

### DIFF
--- a/.changeset/fix-param-flag-description.md
+++ b/.changeset/fix-param-flag-description.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Add format hint to --param flag description for better UX (fixes #1977)

--- a/src/apps/cli/internal/flags/generate/sharedFlags.ts
+++ b/src/apps/cli/internal/flags/generate/sharedFlags.ts
@@ -38,7 +38,7 @@ export const sharedFlags = {
   ),
   param: Flags.string({
     char: 'p',
-    description: 'Additional param to pass to templates',
+    description: 'Additional param to pass to templates (format: name=value)',
     multiple: true
   }),
   'map-base-url': Flags.string({


### PR DESCRIPTION
## What does this PR do?

Improves the `--param` flag description to include the expected format, so users don't have to fail first to discover the correct syntax (fixes #1977)

## Changes

Updated the `--param` flag description in `src/apps/cli/internal/flags/generate/sharedFlags.ts`:

**Before:** `Additional param to pass to templates`
**After:** `Additional param to pass to templates (format: name=value)`

This matches the format shown in the error message from `parseParams.ts`:
```
Invalid param ${input}. It must be in the format of --param name1=value1 name2=value2
```

## Why this matters

Users trying common formats like `--param name:value` or `--param name:value` will now see the correct format in `--help` before encountering an error, improving the CLI's UX.

## Related issue(s)

Fixes #1977

## Checklist

- [x] Updated flag description
- [x] Added changeset
- [x] No test changes needed (no tests assert this description)
