### PR TITLE
docs: add Docker Hub image reference to installation docs (fixes #1799)

### DIFF
--- a/.changeset/fix-docker-docs-image.md
+++ b/.changeset/fix-docker-docs-image.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Add Docker Hub image reference to installation docs (fixes #1799)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,7 +47,25 @@ To refresh the variables:
 
 ## Docker
 
-Install [Docker](https://docs.docker.com/get-docker/) first, then use docker to build the image using the following command :
+Install [Docker](https://docs.docker.com/get-docker/) first.
+
+### Using the pre-built image from Docker Hub
+
+The official image is available at [asyncapi/cli](https://hub.docker.com/r/asyncapi/cli) on Docker Hub. Pull and run it directly:
+
+```bash
+docker pull asyncapi/cli:latest
+
+docker run --rm -it \
+  --user=root \
+  -v [ASYNCAPI SPEC FILE LOCATION]:/app/asyncapi.yml \
+  -v [GENERATED FILES LOCATION]:/app/output \
+  asyncapi/cli [COMMAND HERE]
+```
+
+### Building from source
+
+Alternatively, build the image locally:
 ``` 
 docker build -t asyncapi/cli:latest . 
 ``` 


### PR DESCRIPTION
## What does this PR do?

Adds Docker Hub image reference to the installation documentation (fixes #1799)

## Changes

Updated `docs/installation.md` Docker section to:
1. Add a new "Using the pre-built image from Docker Hub" subsection with `docker pull asyncapi/cli:latest` and usage example
2. Reorganize the existing build-from-source instructions under a "Building from source" subsection

## Why this matters

Previously, the Docker docs only mentioned building from source, which requires cloning the repo and waiting for the build. The official Docker Hub image at [asyncapi/cli](https://hub.docker.com/r/asyncapi/cli) is already published on every release but wasn't documented.

## Related issue(s)

Fixes #1799

## Checklist

- [x] Added Docker Hub image section
- [x] Organized existing content under "Building from source"
- [x] Added changeset
