### PR TITLE
fix: add helpful suggestions to generator error messages (fixes #1728)

### DIFF
--- a/.changeset/fix-generate-error-message.md
+++ b/.changeset/fix-generate-error-message.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Add helpful suggestions to generator error messages (fixes #1728)

--- a/src/apps/cli/commands/generate/fromTemplate.ts
+++ b/src/apps/cli/commands/generate/fromTemplate.ts
@@ -88,7 +88,24 @@ export default class Template extends BaseGeneratorCommand {
       interactive,
     );
     if (!result.success) {
-      throw new GeneratorError(new Error(result.error));
+      const errorMsg = result.error || 'Unknown error';
+      const suggestions: string[] = [];
+
+      if (errorMsg.includes('ENOENT') || errorMsg.includes('not found') || errorMsg.includes('Cannot find')) {
+        suggestions.push('The template may not be installed. Try installing it first with: npm install <template-name>');
+      }
+      if (errorMsg.includes('invalid') || errorMsg.includes('parse') || errorMsg.includes('syntax')) {
+        suggestions.push('The AsyncAPI document may be invalid or unsupported. Verify it with: asyncapi validate <document>');
+      }
+      if (errorMsg.includes('E404') || errorMsg.includes('404')) {
+        suggestions.push('The template was not found on npm. Check the template name and try again.');
+      }
+
+      const fullMessage = suggestions.length > 0
+        ? `${errorMsg}\n\nPossible causes:\n${suggestions.map(s => `  - ${s}`).join('\n')}`
+        : errorMsg;
+
+      throw new GeneratorError(new Error(fullMessage));
     }
 
     // Output logs in non-interactive mode


### PR DESCRIPTION
## What does this PR do?

Adds helpful suggestions to generator error messages when `asyncapi generate fromTemplate` fails (fixes #1728)

## Changes

Enhanced error handling in `src/apps/cli/commands/generate/fromTemplate.ts` to detect common failure patterns and suggest actionable fixes:

- **Template not found** (ENOENT/not found): Suggests installing the template first
- **Invalid document** (parse/syntax errors): Suggests validating the document with `asyncapi validate`
- **404 errors**: Suggests checking the template name on npm

## Before
```
Error: ENOENT: no such file or directory
```

## After
```
Error: ENOENT: no such file or directory

Possible causes:
  - The template may not be installed. Try installing it first with: npm install <template-name>
```

## Related issue(s)

Fixes #1728

## Checklist

- [x] Added error pattern detection for common failures
- [x] Added actionable suggestions
- [x] Preserved original error message when no patterns match
- [x] Added changeset
