### PR TITLE
fix: use COPY --chown to avoid disk space exhaustion on arm64 builds (fixes #1966)

### DIFF
--- a/.changeset/fix-dockerfile-arm64-chown.md
+++ b/.changeset/fix-dockerfile-arm64-chown.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Fix Docker arm64 build failure by using COPY --chown instead of recursive chown (fixes #1966)

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN apk --update add git chromium && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
 
-# Copy the libraries directory from the build stage
-COPY --from=build /libraries /libraries
+# Copy the libraries directory from the build stage with correct ownership
+COPY --from=build --chown=myuser:myuser /libraries /libraries
 
 # Install the dependencies
 RUN cd /libraries && npm install --omit=dev --ignore-scripts
@@ -58,11 +58,8 @@ RUN ln -s /libraries/bin/run_bin /usr/local/bin/asyncapi
 # Make the script executable
 RUN chmod +x /usr/local/bin/asyncapi
 
-# Change ownership to non-root user
-RUN chown -R myuser:myuser /libraries /usr/local/bin/asyncapi || echo "Failed to change ownership"
-
-RUN chown -R myuser:myuser /usr/local/lib/node_modules && \
-chown -R myuser:myuser /usr/local/bin
+# Change ownership only for the symlink, avoiding recursive chown on large directories
+RUN chown myuser:myuser /usr/local/bin/asyncapi
 
 # Switch to the non-root user
 USER myuser

--- a/src/apps/api/Dockerfile
+++ b/src/apps/api/Dockerfile
@@ -46,11 +46,11 @@ WORKDIR /app
 RUN addgroup -g 1001 -S nodejs \
   && adduser -S asyncapi -u 1001
 
-# Copy built code
-COPY --from=build /app/lib ./lib
+# Copy built code with correct ownership
+COPY --from=build --chown=asyncapi:nodejs /app/lib ./lib
 
 # Copy package files
-COPY --from=build /app/package*.json ./
+COPY --from=build --chown=asyncapi:nodejs /app/package*.json ./
 
 # Install production deps, then remove heavy ones
 RUN npm ci --omit=dev --ignore-scripts \
@@ -58,18 +58,12 @@ RUN npm ci --omit=dev --ignore-scripts \
   && npm cache clean --force \
   && npm prune --production
 
-# Copy globally installed templates from templates stage
-COPY --from=templates /usr/local/lib/node_modules /usr/local/lib/node_modules
-COPY --from=templates /usr/local/bin /usr/local/bin
+# Copy globally installed templates from templates stage with correct ownership
+COPY --from=templates --chown=asyncapi:nodejs /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=templates --chown=asyncapi:nodejs /usr/local/bin /usr/local/bin
 
-# Copy OpenAPI document
-COPY openapi.yaml ./
-
-# Change ownership of the app directory to the non-root user
-RUN chown -R asyncapi:nodejs /app
-
-# Change ownership of node_modules to the non-root user
-RUN chown -R asyncapi:nodejs /usr/local/lib/node_modules
+# Copy OpenAPI document with correct ownership
+COPY --chown=asyncapi:nodejs openapi.yaml ./
 
 # Switch to non-root user
 USER asyncapi


### PR DESCRIPTION
Fix Docker arm64 build failure by replacing recursive chown with COPY --chown in both Dockerfiles. Fixes #1966