### PR TITLE
feat: add --compile flag to generate fromTemplate (fixes #1829)

### DIFF
--- a/.changeset/feat-compile-flag.md
+++ b/.changeset/feat-compile-flag.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": minor
+---
+
+Add --compile flag to generate fromTemplate command (fixes #1829)

--- a/src/apps/cli/internal/base/BaseGeneratorCommand.ts
+++ b/src/apps/cli/internal/base/BaseGeneratorCommand.ts
@@ -82,6 +82,9 @@ export abstract class BaseGeneratorCommand extends Command {
     if (flags['map-base-url']) {
       genOption.resolve = { resolve: getMapBaseUrlToFolderResolver(parsedFlags.mapBaseUrlToFolder) };
     }
+    if (flags.compile !== undefined) {
+      genOption.compile = flags.compile;
+    }
     return genOption;
   }
 

--- a/src/apps/cli/internal/flags/generate/sharedFlags.ts
+++ b/src/apps/cli/internal/flags/generate/sharedFlags.ts
@@ -54,4 +54,9 @@ export const sharedFlags = {
   'registry-token': Flags.string({
     description: 'The npm registry authentication token, that can be passed instead of base64 encoded username and password'
   }),
+  compile: Flags.boolean({
+    default: true,
+    allowNo: true,
+    description: 'Compile the template before generation. Disable with --no-compile to skip compilation for pre-transpiled templates (defaults to true)'
+  }),
 };


### PR DESCRIPTION
Add --compile/--no-compile flag to control template compilation. Defaults to true. Fixes #1829