### PR TITLE
fix: skip request body validation gracefully instead of throwing error

### DIFF
--- a/.changeset/mighty-avocados-wash.md
+++ b/.changeset/mighty-avocados-wash.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+fix: skip request body validation gracefully instead of throwing error for unsupported paths

--- a/src/apps/api/middlewares/validation.middleware.ts
+++ b/src/apps/api/middlewares/validation.middleware.ts
@@ -54,13 +54,19 @@ async function compileAjv(options: ValidationMiddlewareOptions) {
 
   const requestBody = method.requestBody;
   if (!requestBody) {
-    return;
+    // No request body defined for this method (e.g., GET, DELETE) — skip validation
+    return undefined;
   }
 
-  let schema = requestBody.content['application/json'].schema;
-  if (!schema) {
-    return;
+  // Handle cases where content type is not application/json
+  // (e.g., multipart/form-data, text/plain, or missing content type)
+  const jsonContent = requestBody.content?.['application/json'];
+  if (!jsonContent?.schema) {
+    // Request body exists but no JSON schema to validate against — skip validation
+    return undefined;
   }
+
+  let schema = jsonContent.schema;
 
   schema = { ...schema };
   schema['$schema'] = 'http://json-schema.org/draft-07/schema';
@@ -174,15 +180,14 @@ export async function validationMiddleware(
 
     try {
       if (!validate) {
-        throw new ProblemException({
-          type: 'invalid-request-body',
-          title: 'Invalid Request Body',
-          status: 422,
-          detail: `Request body validation is not supported for "${options.path}" path with "${options.method}" method.`,
-        });
+        // No validator compiled for this path/method — either:
+        // 1. Method has no requestBody (e.g., GET) — validation not needed, pass through
+        // 2. RequestBody has no JSON schema — nothing to validate, pass through
+        // Do NOT throw "not supported" error for endpoints that simply don't need body validation
+        // Fall through to document validation below
+      } else {
+        await validateRequestBody(validate, req.body);
       }
-
-      await validateRequestBody(validate, req.body);
     } catch (error: unknown) {
       if (error instanceof ProblemException) {
         return next(error);


### PR DESCRIPTION
Fixes #1987

## The Bug

When using request validation in the CLI, request body validation is **skipped or reported as unsupported** for certain paths or HTTP methods, even when a valid request body schema is defined. Two specific issues:

### Bug 1: Unsafe property access crashes validation

`requestBody.content["'application/json'].schema` throws `TypeError: Cannot read properties of undefined` when the content type is not `application/json` (e.g., `multipart/form-data`, `text/plain`, or missing entirely).

**Before:** Direct property access crashes or returns undefined
**After:** Optional chaining `requestBody.content?.["application/json"]?.schema` safely handles missing content types

### Bug 2: Incorrect error for endpoints without request bodies

When `compileAjv()` returns `undefined` (because the method has no requestBody, like GET/DELETE, or the requestBody has no JSON schema), the middleware threw:

```
Request body validation is not supported for "/path" path with "method" method.
```

This is wrong. Methods without request bodies simply **don't need** body validation — it's not an error condition. Endpoints with non-JSON content types should silently skip rather than error.

**Before:** Throws 422 error
**After:** Silently passes through to document validation

## Testing

This mirrors the fix in #2128 but is more surgical — only touches `validation.middleware.ts` and does not include the unrelated URL parsing changes from #1940 (which is addressed separately in #2187).

## Scope

This PR **only** fixes the request body validation bug (#1987). It does not touch the URL parsing or file extension detection (those are in #2187 for #1940).