### PR TITLE
fix: handle GitHub URLs with slash-based branches and multi-dot spec files

### DIFF
--- a/src/apps/cli/commands/new/file.ts
+++ b/src/apps/cli/commands/new/file.ts
@@ -175,7 +175,7 @@ export default class NewFile extends Command {
     if (!fileName.includes('.')) {
       fileNameToWriteToDisk = `${fileName}.yaml`;
     } else {
-      const extension = fileName.split('.')[1];
+      const extension = fileName.includes('.') ? fileName.split('.').pop()?.toLowerCase() : '';
 
       if (extension === 'yml' || extension === 'yaml' || extension === 'json') {
         fileNameToWriteToDisk = fileName;

--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -237,7 +237,7 @@ export async function fileExists(name: string): Promise<boolean> {
       return true;
     }
 
-    const extension = name.split('.')[1];
+    const extension = path.extname(name).slice(1).toLowerCase();
 
     const allowedExtenstion = ['yml', 'yaml', 'json'];
 

--- a/src/domains/services/validation.service.ts
+++ b/src/domains/services/validation.service.ts
@@ -62,20 +62,23 @@ const isValidGitHubBlobUrl = (url: string): boolean => {
 };
 
 /**
- * Convert GitHub web URL to API URL
+ * Convert GitHub web URL to raw content URL
  */
 const convertGitHubWebUrl = (url: string): string => {
   // Remove fragment from URL before processing
   const urlWithoutFragment = url.split('#')[0];
 
   // Handle GitHub web URLs like: https://github.com/owner/repo/blob/branch/path
-  // eslint-disable-next-line no-useless-escape
-  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/;
+  // Also handles branch names with slashes like: https://github.com/owner/repo/blob/feature/new-validation/spec.yaml
+  // Using raw.githubusercontent.com avoids the need to split branch/path at the regex level,
+  // since branch names can contain slashes (e.g. "feature/new-validation") and the raw URL
+  // format handles this correctly.
+  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/(.+)$/;
   const match = urlWithoutFragment.match(githubWebPattern);
 
   if (match) {
-    const [, owner, repo, branch, filePath] = match;
-    return `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`;
+    const [, owner, repo, refAndPath] = match;
+    return `https://raw.githubusercontent.com/${owner}/${repo}/${refAndPath}`;
   }
 
   return url;


### PR DESCRIPTION
## Summary

Fixes two CLI validation bugs reported in #1940:

### 1. GitHub URL Parsing

The regex for parsing GitHub blob URLs assumed branch names do not contain slashes (`/`), causing failures for valid URLs like:
```
https://github.com/org/repo/blob/feature/new-validation/spec.yaml
```

**Fix:** Instead of trying to split the branch from the path at the regex level (which is impossible since both can contain slashes), convert GitHub blob URLs to `raw.githubusercontent.com` URLs which naturally handle branch names with slashes:
```
https://raw.githubusercontent.com/org/repo/feature/new-validation/spec.yaml
```

This also eliminates the need for the GitHub Contents API call, simplifying the code path.

### 2. File Extension Detection

Used `name.split(".")[1]` which only gets the first part after the dot, failing for multi-dot filenames:
- `my.asyncapi.yaml` → returned `"asyncapi"` instead of `"yaml"`
- `asyncapi` (no extension) → returned `undefined` causing crashes

**Fix:** 
- In `SpecificationFile.ts`: Use `path.extname()` which correctly extracts the last extension
- In `new/file.ts`: Use `.split(".").pop()` which gets the last segment after dots

## Test Plan

- [x] Verified regex correctly matches simple branch URLs: `https://github.com/org/repo/blob/main/spec.yaml`
- [x] Verified regex correctly matches slash-containing branch URLs: `https://github.com/org/repo/blob/feature/new-validation/spec.yaml`
- [x] Verified `path.extname()` correctly handles `my.asyncapi.yaml` → `.yaml`
- [x] Verified `path.extname()` correctly handles `asyncapi` → `""` (empty)
- [x] Existing validation service tests still pass

Closes #1940