### PR TITLE
fix: handle slash-based branch names in GitHub URLs and multi-dot file extensions

### DIFF
--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -237,7 +237,8 @@ export async function fileExists(name: string): Promise<boolean> {
       return true;
     }
 
-    const extension = name.split('.')[1];
+    const parts = name.split('.');
+    const extension = parts.length > 1 ? parts[parts.length - 1] : '';
 
     const allowedExtenstion = ['yml', 'yaml', 'json'];
 

--- a/src/domains/services/validation.service.ts
+++ b/src/domains/services/validation.service.ts
@@ -62,6 +62,23 @@ const isValidGitHubBlobUrl = (url: string): boolean => {
 };
 
 /**
+ * Split the full path after blob/ into branch and file path.
+ * Last path segment is always the file; everything before is the branch.
+ * Example: "feature/new-validation/spec.yaml" → branch="feature/new-validation", file="spec.yaml"
+ */
+const splitBranchAndPath = (fullPath: string): { branch: string; filePath: string } => {
+  const lastSlash = fullPath.lastIndexOf('/');
+  if (lastSlash === -1) {
+    // No branch in URL — use empty branch (API defaults to repo default branch)
+    return { branch: '', filePath: fullPath };
+  }
+  return {
+    branch: fullPath.substring(0, lastSlash),
+    filePath: fullPath.substring(lastSlash + 1),
+  };
+};
+
+/**
  * Convert GitHub web URL to API URL
  */
 const convertGitHubWebUrl = (url: string): string => {
@@ -69,13 +86,16 @@ const convertGitHubWebUrl = (url: string): string => {
   const urlWithoutFragment = url.split('#')[0];
 
   // Handle GitHub web URLs like: https://github.com/owner/repo/blob/branch/path
+  // Branch names can contain slashes (e.g. feature/new-validation)
   // eslint-disable-next-line no-useless-escape
-  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/;
+  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/(.+)$/;
   const match = urlWithoutFragment.match(githubWebPattern);
 
   if (match) {
-    const [, owner, repo, branch, filePath] = match;
-    return `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`;
+    const [, owner, repo, fullPath] = match;
+    const { branch, filePath } = splitBranchAndPath(fullPath);
+    const refParam = branch ? `?ref=${branch}` : '';
+    return `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}${refParam}`;
   }
 
   return url;


### PR DESCRIPTION
## Description
Fixes two validation bugs in the CLI causing valid inputs to fail:

1. **GitHub URL parsing**: The regex `([^\/]+)` for branch names rejected branches containing `/` (e.g., `feature/new-validation`). Fixed by capturing the full path after `blob/` and splitting branch from file path using `lastIndexOf('/')`.

2. **File extension detection**: `name.split('.')[1]` failed for multi-dot filenames like `my.asyncapi.yaml` (returned `asyncapi` instead of `yaml`) and filenames without extensions (returned `undefined`). Fixed by using `parts[parts.length - 1]`.

## Changes
- `src/domains/services/validation.service.ts`: Updated `convertGitHubWebUrl` regex and added `splitBranchAndPath` helper
- `src/domains/models/SpecificationFile.ts`: Fixed `fileExists` extension detection

## Testing
- All 60 existing unit tests pass
- Verified with:
  - `https://github.com/org/repo/blob/feature/new-validation/spec.yaml` → `?ref=feature/new-validation`
  - `my.asyncapi.yaml` → extension `yaml`
  - `asyncapi` (no extension) → extension ``

Fixes #1940

/claim #1940