### PR TITLE
fix: avoid invalid v3 optimized schema refs

### DIFF
--- a/.changeset/fix-v3-optimized-schema-refs.md
+++ b/.changeset/fix-v3-optimized-schema-refs.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Avoid invalid schema references when optimizing AsyncAPI 3.x documents.

--- a/src/apps/cli/commands/optimize.ts
+++ b/src/apps/cli/commands/optimize.ts
@@ -7,6 +7,7 @@ import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { promises } from 'fs';
 import { Parser } from '@asyncapi/parser';
+import { load as loadYaml } from 'js-yaml';
 import { optimizeFlags } from '@cli/internal/flags/optimize.flags';
 import { proxyFlags } from '@cli/internal/flags/proxy.flags';
 import { applyProxyToPath } from '@utils/proxy';
@@ -29,6 +30,24 @@ export enum Outputs {
   NEW_FILE = 'new-file',
   OVERWRITE = 'overwrite',
 }
+
+function isAsyncApiV3Document(document: string): boolean {
+  try {
+    const parsedDocument = loadYaml(document) as { asyncapi?: unknown } | null;
+    return typeof parsedDocument?.asyncapi === 'string' && parsedDocument.asyncapi.startsWith('3.');
+  } catch {
+    return false;
+  }
+}
+
+function getDisabledOptimizationsForDocument(document: string, disabledOptimizations: DisableOptimizations[]): DisableOptimizations[] {
+  if (!isAsyncApiV3Document(document)) {
+    return disabledOptimizations;
+  }
+
+  return Array.from(new Set([...disabledOptimizations, DisableOptimizations.SCHEMA]));
+}
+
 export default class Optimize extends Command {
   static description = 'optimize asyncapi specification file';
   isInteractive = false;
@@ -103,7 +122,8 @@ export default class Optimize extends Command {
     }
     this.isInteractive = !flags['no-tty'];
     this.selectedOptimizations = flags.optimization as Optimizations[];
-    this.disableOptimizations = flags.ignore as DisableOptimizations[];
+    const disabledOptimizations = flags.ignore as DisableOptimizations[];
+    this.disableOptimizations = getDisabledOptimizationsForDocument(this.specFile.text(), disabledOptimizations);
     this.outputMethod = flags.output as Outputs;
     this.metricsMetadata.optimized = false;
 

--- a/test/fixtures/dummyspec/optimize-v3-invalid-output.yml
+++ b/test/fixtures/dummyspec/optimize-v3-invalid-output.yml
@@ -1,0 +1,56 @@
+asyncapi: 3.0.0
+id: urn:com:example
+info:
+  title: x
+  version: 1.4.0
+operations:
+  A:
+    action: send
+    description: ''
+    channel:
+      $ref: '#/channels/A'
+    messages:
+      - $ref: '#/channels/A/messages/A'
+channels:
+  A:
+    address: ''
+    title: ''
+    messages:
+      A:
+        $ref: '#/components/messages/A'
+components:
+  messages:
+    A:
+      contentType: application/json
+      payload:
+        allOf:
+          - $ref: '#/components/schemas/EventEnvelope'
+          - $ref: '#/components/schemas/EnvelopeOverrides'
+          - type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/A'
+  schemas:
+    A:
+      description: ''
+      type: object
+      properties:
+        a:
+          type: string
+          minLength: 1
+          examples:
+            - 669e01d59ba47d8e3e21cf13
+      required:
+        - a
+    EnvelopeOverrides:
+      description: Envelope overrides for this event
+      type: object
+      properties:
+        type:
+          type: string
+          const: a
+      required:
+        - type
+    EventEnvelope:
+      allOf:
+        - $ref: https://raw.githubusercontent.com/cloudevents/spec/v1.0.2/cloudevents/formats/cloudevents.json

--- a/test/integration/optimize.test.ts
+++ b/test/integration/optimize.test.ts
@@ -10,6 +10,7 @@ const testHelper = new TestHelper();
 const optimizedFilePath = './test/fixtures/specification.yml';
 const unoptimizedYamlFile = './test/fixtures/dummyspec/unoptimizedSpec.yml';
 const unoptimizedJsonFile = './test/fixtures/dummyspec/unoptimizedSpec.json';
+const unoptimizedV3File = './test/fixtures/dummyspec/optimize-v3-invalid-output.yml';
 const invalidFile = './test/fixtures/specification-invalid.yml';
 const asyncapiv3 = './test/fixtures/specification-v3.yml';
 
@@ -166,6 +167,23 @@ describe('optimize', () => {
         fs.unlinkSync(optimizedFile);
         done();
       });
+
+    test
+      .stderr()
+      .stdout()
+      .command(['optimize', unoptimizedV3File, '--no-tty', '-o', 'new-file'])
+      .it('does not emit invalid schema refs for AsyncAPI v3 documents', (ctx, done) => {
+        const pos = unoptimizedV3File.lastIndexOf('.');
+        const optimizedFile = `${unoptimizedV3File.substring(0, pos)}_optimized.${unoptimizedV3File.substring(pos + 1)}`;
+        const optimizedDocument = fs.readFileSync(optimizedFile, 'utf8');
+
+        expect(ctx.stdout).to.contain(`✅ Success! Your optimized file has been created at ${optimizedFile}.`);
+        expect(ctx.stderr).to.equal('');
+        expect(optimizedDocument).to.not.contain('#/components/schemas/[');
+        expect(optimizedDocument).to.not.contain('#/components/schemas/type');
+        fs.unlinkSync(optimizedFile);
+        done();
+      });
   });
 
   describe('interactive terminal', () => {
@@ -192,4 +210,3 @@ describe('optimize', () => {
       });
   });
 });
-


### PR DESCRIPTION
Fixes #1990.

This keeps asyncapi optimize --no-tty from producing invalid AsyncAPI 3.x documents when schema optimization rewrites nested/external schema refs into missing component refs. For AsyncAPI v3 documents, the CLI now adds the existing schema ignore mode automatically so non-schema optimizations can still run while preserving valid output.

Verification:
- npm run build
- npm run test:one -- test/integration/optimize.test.ts
- npm run lint
- git diff --check
- Manual repro: optimized test/fixtures/dummyspec/optimize-v3-invalid-output.yml, scanned for invalid schema refs, then validated the generated file successfully.