### PR TITLE
fix: handle GitHub URLs with slash-based branches and multi-dot filenames

### DIFF
--- a/.changeset/fix-url-and-extension-parsing.md
+++ b/.changeset/fix-url-and-extension-parsing.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/cli": patch
+---
+
+Fix GitHub URL parsing for branches with slashes and file extension detection for multi-dot filenames

--- a/src/apps/cli/commands/new/file.ts
+++ b/src/apps/cli/commands/new/file.ts
@@ -175,7 +175,8 @@ export default class NewFile extends Command {
     if (!fileName.includes('.')) {
       fileNameToWriteToDisk = `${fileName}.yaml`;
     } else {
-      const extension = fileName.split('.')[1];
+      const parts = fileName.split('.');
+      const extension = parts.length > 1 ? parts.pop()!.toLowerCase() : '';
 
       if (extension === 'yml' || extension === 'yaml' || extension === 'json') {
         fileNameToWriteToDisk = fileName;

--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -237,11 +237,12 @@ export async function fileExists(name: string): Promise<boolean> {
       return true;
     }
 
-    const extension = name.split('.')[1];
+    const parts = name.split('.');
+    const extension = parts.length > 1 ? parts.pop()!.toLowerCase() : '';
 
     const allowedExtenstion = ['yml', 'yaml', 'json'];
 
-    if (!allowedExtenstion.includes(extension)) {
+    if (!extension || !allowedExtenstion.includes(extension)) {
       throw new ErrorLoadingSpec('invalid file', name);
     }
 

--- a/src/domains/services/validation.service.ts
+++ b/src/domains/services/validation.service.ts
@@ -69,13 +69,16 @@ const convertGitHubWebUrl = (url: string): string => {
   const urlWithoutFragment = url.split('#')[0];
 
   // Handle GitHub web URLs like: https://github.com/owner/repo/blob/branch/path
+  // Branch names can contain slashes (e.g. feature/new-validation), so we capture
+  // everything after /blob/ and use raw.githubusercontent.com which resolves the
+  // branch/path split internally.
   // eslint-disable-next-line no-useless-escape
-  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/;
+  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/(.+)$/;
   const match = urlWithoutFragment.match(githubWebPattern);
 
   if (match) {
-    const [, owner, repo, branch, filePath] = match;
-    return `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`;
+    const [, owner, repo, branchAndPath] = match;
+    return `https://raw.githubusercontent.com/${owner}/${repo}/${branchAndPath}`;
   }
 
   return url;


### PR DESCRIPTION
## Summary
Fixes #1940

This PR fixes two validation bugs in the CLI:

### 1. GitHub URL Parsing (slash-based branches)
**Before:** The regex `([^\/]+)` for branch capture failed on branches with slashes (e.g., `feature/new-validation`), causing 404 errors.

**After:** Captures everything after `/blob/` and converts to `raw.githubusercontent.com` URL, which resolves the branch/path ambiguity internally. This correctly handles:
- `https://github.com/org/repo/blob/feature/new-validation/spec.yaml`
- `https://github.com/org/repo/blob/main/spec.yaml` (still works)

### 2. File Extension Detection (multi-dot filenames)
**Before:** `name.split('.')[1]` extracted the wrong segment for multi-dot filenames:
- `my.asyncapi.yaml` → extracted `asyncapi` instead of `yaml`
- `asyncapi` (no extension) → extracted `undefined`

**After:** Uses `parts.pop()` to correctly extract the last extension:
- `my.asyncapi.yaml` → extracts `yaml` ✓
- `asyncapi` (no extension) → handled gracefully ✓

### Files Changed
- `src/domains/services/validation.service.ts` — GitHub URL conversion
- `src/domains/models/SpecificationFile.ts` — `fileExists()` extension check
- `src/apps/cli/commands/new/file.ts` — `createAsyncapiFile()` extension check

### How to Test
```bash
# Test 1: GitHub URL with slash-branch (should no longer 404)
asyncapi validate https://github.com/org/repo/blob/feature/branch/spec.yaml

# Test 2: Multi-dot filename
asyncapi validate my.asyncapi.yaml

# Test 3: Existing behavior still works
asyncapi validate spec.yaml
asyncapi validate https://github.com/org/repo/blob/main/spec.yaml
```