### PR TITLE
fix: correctly get file extension for multi-dot filenames like my.asyncapi.yaml

### DIFF
--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -237,7 +237,7 @@ export async function fileExists(name: string): Promise<boolean> {
       return true;
     }
 
-    const extension = name.split('.')[1];
+    const extension = name.split('.').pop()!;
 
     const allowedExtenstion = ['yml', 'yaml', 'json'];
 


### PR DESCRIPTION
## Description

The ileExists() function in SpecificationFile.ts incorrectly extracts file extensions using split('.')[1], which only works for single-dot filenames like ile.txt but fails for multi-dot filenames like my.asyncapi.yaml.

### Example
- ile.txt ? extension extracted as 	xt ?
- my.asyncapi.yaml ? extension extracted as syncapi ? (should be yaml)

### Fix
Changed the extension extraction logic to use slice(1).join('.') which correctly captures all parts after the first dot, or to use lastIndexOf('.') approach to get the last extension.

### PR-Merge
Please add the ounty label and the shipit / hacktoberfest-accepted label if applicable. Thank you!