### PR TITLE
fix: resolve GitHub URLs with slash-based branches and multi-dot filenames

### DIFF
--- a/.changeset/fix-github-slash-branches-multiext.md
+++ b/.changeset/fix-github-slash-branches-multiext.md
@@ -1,0 +1,15 @@
+---
+'@asyncapi/cli': patch
+---
+
+fix: resolve GitHub URLs with slash-based branches and multi-dot filenames
+
+- Replace single-candidate URL conversion with retry-on-404 logic that tries
+  all possible branch/path splits for GitHub blob URLs. Branch names such as
+  `feature/my-fix` are now handled correctly without requiring any API
+  pre-checks.
+- Fix file extension detection in `fileExists` to use `path.extname()` instead
+  of `name.split('.')[1]`, which returned the wrong segment for filenames with
+  multiple dots (e.g. `my.asyncapi.yaml`).
+
+Fixes #1940.

--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -237,7 +237,7 @@ export async function fileExists(name: string): Promise<boolean> {
       return true;
     }
 
-    const extension = name.split('.')[1];
+    const extension = path.extname(name).slice(1).toLowerCase();
 
     const allowedExtenstion = ['yml', 'yaml', 'json'];
 

--- a/src/domains/services/validation.service.ts
+++ b/src/domains/services/validation.service.ts
@@ -62,23 +62,33 @@ const isValidGitHubBlobUrl = (url: string): boolean => {
 };
 
 /**
- * Convert GitHub web URL to API URL
+ * Generate all candidate GitHub API URLs for a blob URL by trying every possible
+ * branch/path split. GitHub branch names may contain slashes (e.g. feature/my-fix),
+ * so the split point is ambiguous without querying the API.
+ *
+ * Returns candidates ordered from shortest branch (most common case) to longest.
  */
-const convertGitHubWebUrl = (url: string): string => {
-  // Remove fragment from URL before processing
+const generateGitHubApiCandidates = (url: string): string[] => {
   const urlWithoutFragment = url.split('#')[0];
-
-  // Handle GitHub web URLs like: https://github.com/owner/repo/blob/branch/path
   // eslint-disable-next-line no-useless-escape
-  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/;
-  const match = urlWithoutFragment.match(githubWebPattern);
+  const match = urlWithoutFragment.match(
+    /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/(.+)$/
+  );
+  if (!match) return [];
 
-  if (match) {
-    const [, owner, repo, branch, filePath] = match;
-    return `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`;
+  const [, owner, repo, blobPath] = match;
+  const segments = blobPath.split('/');
+  if (segments.length < 2) return [];
+
+  const candidates: string[] = [];
+  for (let i = 0; i < segments.length - 1; i++) {
+    const branch = segments.slice(0, i + 1).join('/');
+    const filePath = segments.slice(i + 1).join('/');
+    candidates.push(
+      `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}?ref=${branch}`
+    );
   }
-
-  return url;
+  return candidates;
 };
 
 /**
@@ -142,13 +152,27 @@ const createHttpWithAuthResolver = () => ({
 
     const authInfo = await ConfigService.getAuthForUrl(url);
 
-    if (isValidGitHubBlobUrl(url)) {
-      url = convertGitHubWebUrl(url);
-    }
-
     if (authInfo) {
       headers['Authorization'] = `${authInfo.authType} ${authInfo.token}`;
       Object.assign(headers, authInfo.headers); // merge custom headers
+    }
+
+    if (isValidGitHubBlobUrl(url)) {
+      const candidates = generateGitHubApiCandidates(url);
+      let lastError: Error | undefined;
+      for (const candidate of candidates) {
+        try {
+          return await fetchGitHubApiContent(candidate, headers);
+        } catch (err: any) {
+          // Only retry on 404 — other errors (auth, server) should propagate immediately
+          if (/\b(404|Not Found)\b/.test(err?.message ?? '')) {
+            lastError = err;
+            continue;
+          }
+          throw err;
+        }
+      }
+      throw lastError ?? new Error(`Failed to resolve GitHub URL: ${url}`);
     }
 
     if (url.includes('api.github.com')) {


### PR DESCRIPTION
## Summary

Fixes two parsing bugs from #1940.

### Bug 1 — GitHub URL with slash-based branch names

**Root cause:** The previous implementation used a regex with `([^\/]+)` for the
branch segment, which stops at the first `/`. A branch like `feature/my-fix`
was parsed as branch=`feature` and path=`my-fix/spec.yaml`, producing an
incorrect GitHub API URL that returned 404.

**Why this is genuinely hard to fix with a simple regex change:**
The URL `https://github.com/org/repo/blob/feature/new-validation/spec.yaml`
is structurally ambiguous — you cannot tell from the URL alone where the branch
ends and the file path begins. Changing `([^\/]+)` to `(.+?)` (as done in several
other PRs) still uses a lazy match that resolves to the shortest branch, i.e. the
same broken behaviour.

**Fix:** Replace `convertGitHubWebUrl` with `generateGitHubApiCandidates`, which
produces every possible branch/path split ordered from shortest branch to longest.
The `read()` function tries each candidate and retries only on HTTP 404. Other
errors (authentication failures, server errors) propagate immediately without
retrying. This correctly handles all branch naming conventions without any
hard-coded heuristics.

```
URL: https://github.com/org/repo/blob/feature/my-fix/spec.yaml
Candidates tried:
  1. /repos/org/repo/contents/my-fix/spec.yaml?ref=feature        → 404, retry
  2. /repos/org/repo/contents/spec.yaml?ref=feature/my-fix        → 200 ✓
```

**Bonus fix:** Auth headers are now populated **before** the candidate-retry loop,
ensuring credentials are available on all retry attempts. The original code
fetched the auth config but applied it to `headers` after the blob URL had been
converted — a race that was benign before this change but is now important.

### Bug 2 — Wrong extension for multi-dot filenames

**Root cause:** `name.split('.')[1]` returns the *second* segment, which is wrong
for filenames like `my.asyncapi.yaml` (returns `asyncapi`) and crashes for
filenames without a dot (returns `undefined`).

**Fix:** `path.extname(name).slice(1).toLowerCase()` correctly returns the
trailing extension in all cases. `path` is already imported.

## Test plan

- [ ] `asyncapi validate https://github.com/org/repo/blob/feature/my-fix/spec.yaml` resolves correctly
- [ ] `asyncapi validate my.asyncapi.yaml` no longer rejects the file
- [ ] Existing private-ref tests pass (`npm run test:unit`)
- [ ] `npm run build` succeeds