### PR TITLE
fix(cli): correct GitHub URL branch parsing and file extension detection

### DIFF
--- a/src/domains/models/SpecificationFile.ts
+++ b/src/domains/models/SpecificationFile.ts
@@ -237,7 +237,8 @@ export async function fileExists(name: string): Promise<boolean> {
       return true;
     }
 
-    const extension = name.split('.')[1];
+    const parts = name.split('.');
+    const extension = parts.length > 1 ? parts[parts.length - 1] : '';
 
     const allowedExtenstion = ['yml', 'yaml', 'json'];
 

--- a/src/domains/services/validation.service.ts
+++ b/src/domains/services/validation.service.ts
@@ -70,7 +70,7 @@ const convertGitHubWebUrl = (url: string): string => {
 
   // Handle GitHub web URLs like: https://github.com/owner/repo/blob/branch/path
   // eslint-disable-next-line no-useless-escape
-  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/;
+  const githubWebPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/(.+?)\/(.+)$/;
   const match = urlWithoutFragment.match(githubWebPattern);
 
   if (match) {


### PR DESCRIPTION
Fixes #1940.

### Bug fixes included:
1. **GitHub URL Branch Parsing:** Updated `githubWebPattern` in `validation.service.ts` from `([^\/]+)` to `(.+?)` for the branch capture group. This correctly allows URLs with slash-based branch names (e.g., `feature/new-validation`) to be parsed instead of throwing a 404.
2. **File Extension Extraction:** Updated the hardcoded `name.split('.')[1]` extraction in `SpecificationFile.ts` to intelligently use the last element of the split array (`parts[parts.length - 1]`). This gracefully handles multi-dot filenames like `my.asyncapi.yaml` and single-word files.

Bounty Wallet: 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp (Solana) / Algora