### PR TITLE
perf: improve CLI startup speed and local build speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .idea
 /.nyc_output
 /dist
+.tsbuildinfo
 /dist/
 /lib
 /node_modules/

--- a/scripts/fetch-asyncapi-example.js
+++ b/scripts/fetch-asyncapi-example.js
@@ -119,10 +119,9 @@ const tidyUp = async () => {
 };
 
 (async () => {
-  // Skips the network download if examples already exists locally
   const exampleJsonPath = path.join(EXAMPLE_DIRECTORY, 'examples.json');
   if (fs.existsSync(exampleJsonPath) && !process.env.FORCE_FETCH_EXAMPLES) {
-    console.log('AsyncAPI spec examples already exists. Skipping download.')
+    console.log('AsyncAPI spec examples already exists. Skipping download.');
     return;
   }
 

--- a/scripts/fetch-asyncapi-example.js
+++ b/scripts/fetch-asyncapi-example.js
@@ -119,6 +119,13 @@ const tidyUp = async () => {
 };
 
 (async () => {
+  // Skips the network download if examples already exists locally
+  const exampleJsonPath = path.join(EXAMPLE_DIRECTORY, 'examples.json');
+  if (fs.existsSync(exampleJsonPath) && !process.env.FORCE_FETCH_EXAMPLES) {
+    console.log('AsyncAPI spec examples already exists. Skipping download.')
+    return;
+  }
+
   await fetchAsyncAPIExamplesFromExternalURL();
   await unzipAsyncAPIExamples();
   await buildCLIListFromExamples();

--- a/src/apps/cli/commands/convert.ts
+++ b/src/apps/cli/commands/convert.ts
@@ -8,7 +8,7 @@ import { cyan } from 'picocolors';
 import { proxyFlags } from '@cli/internal/flags/proxy.flags';
 import specs from '@asyncapi/specs';
 import { convertFlags } from '@cli/internal/flags/convert.flags';
-import { ConversionService } from '@services/convert.service';
+import type { ConversionService } from '@services/convert.service';
 import { applyProxyToPath } from '@utils/proxy';
 
 const latestVersion = Object.keys(specs.schemas).pop() as string;
@@ -17,7 +17,7 @@ const TARGET_VERSION_FLAG = 'target-version';
 export default class Convert extends Command {
   static description =
     'Convert asyncapi documents older to newer versions or OpenAPI documents to AsyncAPI';
-  private conversionService = new ConversionService();
+  private _conversionService?: ConversionService;
   static flags = {
     ...convertFlags(latestVersion),
     ...proxyFlags(),
@@ -29,6 +29,15 @@ export default class Convert extends Command {
       required: false,
     }),
   };
+
+  private async getConversionService(): Promise<ConversionService> {
+    if (!this._conversionService) {
+      const { ConversionService: cService } = await import('@services/convert.service');
+      this._conversionService = new cService();
+    }
+
+    return this._conversionService;
+  }
 
   async run() {
     const { args, flags } = await this.parse(Convert);
@@ -50,7 +59,8 @@ export default class Convert extends Command {
         perspective: flags['perspective'] as 'client' | 'server',
       };
 
-      const result = await this.conversionService.convertDocument(
+      const cService = await this.getConversionService();
+      const result = await cService.convertDocument(
         this.specFile,
         conversionOptions,
       );
@@ -62,11 +72,11 @@ export default class Convert extends Command {
       this.metricsMetadata.conversion_result = result;
 
       this.log(
-        this.conversionService.handleLogging(this.specFile, conversionOptions),
+        cService.handleLogging(this.specFile, conversionOptions),
       );
 
       if (flags['output']) {
-        await this.conversionService.handleOutput(
+        await cService.handleOutput(
           flags['output'],
           result.data.convertedDocument,
         );

--- a/src/apps/cli/commands/validate.ts
+++ b/src/apps/cli/commands/validate.ts
@@ -9,15 +9,12 @@ import {
   ValidationOptions,
   ValidationResult,
 } from '@/interfaces';
-import {
-  ValidationService,
-  ValidationStatus,
-} from '@services/validation.service';
+import type { ValidationService, } from '@services/validation.service';
 import { applyProxyToPath } from '@utils/proxy';
 
 export default class Validate extends Command {
   static description = 'validate asyncapi file';
-  private validationService = new ValidationService();
+  private _validationService?: ValidationService;
 
   static flags = {
     ...validateFlags(),
@@ -57,7 +54,8 @@ export default class Validate extends Command {
       suppressAllWarnings: flags['suppressAllWarnings'],
     };
 
-    const result = await this.validationService.validateDocument(
+    const vService = await this.getValidationService();
+    const result = await vService.validateDocument(
       this.specFile,
       validateOptions,
     );
@@ -76,9 +74,19 @@ export default class Validate extends Command {
       await this.handleDiagnostics(result, flags);
     }
 
+    const { ValidationStatus } = await import('@services/validation.service');
     if (result.data?.status === ValidationStatus.INVALID) {
       process.exitCode = 1;
     }
+  }
+
+  private async getValidationService(): Promise<ValidationService> {
+    if (!this._validationService) {
+      const { ValidationService: vService } = await import('@services/validation.service');
+      this._validationService = new vService();
+    }
+
+    return this._validationService;
   }
 
   private async handleDiagnostics(
@@ -89,10 +97,12 @@ export default class Validate extends Command {
     const writeOutput = flags['save-output'];
     const hasIssues =
       (result.data?.diagnostics && result.data.diagnostics.length > 0) ?? false;
+    const { ValidationStatus } = await import('@services/validation.service');
     const isFailSeverity = result.data?.status === ValidationStatus.INVALID;
     const sourceString = this.specFile?.toSourceString() || '';
 
-    const governanceMessage = this.validationService.generateGovernanceMessage(
+    const vService = await this.getValidationService();
+    const governanceMessage = vService.generateGovernanceMessage(
       sourceString,
       hasIssues,
       isFailSeverity,
@@ -104,7 +114,7 @@ export default class Validate extends Command {
       this.log(governanceMessage);
     }
 
-    const diagnosticsOutput = this.validationService.formatDiagnosticsOutput(
+    const diagnosticsOutput = vService.formatDiagnosticsOutput(
       result.data?.diagnostics || [],
       diagnosticsFormat,
       flags['fail-severity'] ?? 'error',
@@ -112,7 +122,7 @@ export default class Validate extends Command {
 
     if (writeOutput) {
       const { success, error } =
-        await this.validationService.saveDiagnosticsToFile(
+        await vService.saveDiagnosticsToFile(
           writeOutput,
           diagnosticsFormat,
           diagnosticsOutput,

--- a/src/apps/cli/internal/base.ts
+++ b/src/apps/cli/internal/base.ts
@@ -7,7 +7,7 @@ import {
   Sink,
   StdOutSink,
 } from '@smoya/asyncapi-adoption-metrics';
-import { Parser } from '@asyncapi/parser';
+import type { Parser } from '@asyncapi/parser';
 import { Specification } from '@models/SpecificationFile';
 import { join, resolve } from 'path';
 import { existsSync } from 'fs-extra';
@@ -25,9 +25,18 @@ class DiscardSink implements Sink {
 
 export default abstract class extends Command {
   recorder = this.recorderFromEnv('asyncapi_adoption');
-  parser = new Parser();
+  private _parser?: Parser;
   metricsMetadata: MetricMetadata = {};
   specFile: Specification | undefined;
+
+  async getParser(): Promise<Parser> {
+    if (!this._parser) {
+      const { Parser: AsyncAPIParser } = await import('@asyncapi/parser');
+      this._parser = new AsyncAPIParser();
+    }
+
+    return this._parser;
+  }
 
   async init(): Promise<void> {
     await super.init();
@@ -57,7 +66,8 @@ export default abstract class extends Command {
   ) {
     if (rawDocument !== undefined) {
       try {
-        const { document } = await this.parser.parse(rawDocument);
+        const parser = await this.getParser();
+        const { document } = await parser.parse(rawDocument);
         if (document !== undefined) {
           // @ts-ignore
           metadata = MetadataFromDocument(document, metadata);
@@ -150,32 +160,32 @@ export default abstract class extends Command {
       process.env.CI !== 'true'
     ) {
       switch (process.env.NODE_ENV) {
-      case 'development':
-        // NODE_ENV set to `development` in bin/run
-        if (!process.env.TEST) {
-          // Do not pollute stdout when running tests
-          sink = new StdOutSink();
-        }
-        break;
-      case 'production':
-        // NODE_ENV set to `production` in bin/run_bin, which is specified in 'bin' package.json section
-        sink = new NewRelicSink(
-          process.env.ASYNCAPI_METRICS_NEWRELIC_KEY ||
-              'eu01xx73a8521047150dd9414f6aedd2FFFFNRAL',
-        );
+        case 'development':
+          // NODE_ENV set to `development` in bin/run
+          if (!process.env.TEST) {
+            // Do not pollute stdout when running tests
+            sink = new StdOutSink();
+          }
+          break;
+        case 'production':
+          // NODE_ENV set to `production` in bin/run_bin, which is specified in 'bin' package.json section
+          sink = new NewRelicSink(
+            process.env.ASYNCAPI_METRICS_NEWRELIC_KEY ||
+            'eu01xx73a8521047150dd9414f6aedd2FFFFNRAL',
+          );
 
-        if (analyticsConfigFileContent.infoMessageShown === 'false') {
-          this.log(
-            '\nAsyncAPI anonymously tracks command executions to improve the specification and tools, ensuring no sensitive data reaches our servers. It aids in comprehending how AsyncAPI tools are used and adopted, facilitating ongoing improvements to our specifications and tools.\n\nTo disable tracking, please run the following command:\n  asyncapi config analytics --disable\n\nOnce disabled, if you want to enable tracking back again then run:\n  asyncapi config analytics --enable\n',
-          );
-          analyticsConfigFileContent.infoMessageShown = 'true';
-          await writeFile(
-            analyticsConfigFile,
-            JSON.stringify(analyticsConfigFileContent),
-            { encoding: 'utf8' },
-          );
-        }
-        break;
+          if (analyticsConfigFileContent.infoMessageShown === 'false') {
+            this.log(
+              '\nAsyncAPI anonymously tracks command executions to improve the specification and tools, ensuring no sensitive data reaches our servers. It aids in comprehending how AsyncAPI tools are used and adopted, facilitating ongoing improvements to our specifications and tools.\n\nTo disable tracking, please run the following command:\n  asyncapi config analytics --disable\n\nOnce disabled, if you want to enable tracking back again then run:\n  asyncapi config analytics --enable\n',
+            );
+            analyticsConfigFileContent.infoMessageShown = 'true';
+            await writeFile(
+              analyticsConfigFile,
+              JSON.stringify(analyticsConfigFileContent),
+              { encoding: 'utf8' },
+            );
+          }
+          break;
       }
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "outDir": "./lib",
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuildinfo",
     "baseUrl": "./src",
     "target": "es6",
     "module": "commonjs",
@@ -8,15 +10,33 @@
       "esnext",
     ],
     "paths": {
-      "@/*": ["*"],
-      "@src/*": ["*"],
-      "@cli/*": ["apps/cli/*"],
-      "@api/*": ["apps/api/*"],
-      "@services/*": ["domains/services/*"],
-      "@models/*": ["domains/models/*"],
-      "@utils/*": ["utils/*"],
-      "@errors/*": ["errors/*"],
-      "@interfaces/*": ["interfaces/*"],
+      "@/*": [
+        "*"
+      ],
+      "@src/*": [
+        "*"
+      ],
+      "@cli/*": [
+        "apps/cli/*"
+      ],
+      "@api/*": [
+        "apps/api/*"
+      ],
+      "@services/*": [
+        "domains/services/*"
+      ],
+      "@models/*": [
+        "domains/models/*"
+      ],
+      "@utils/*": [
+        "utils/*"
+      ],
+      "@errors/*": [
+        "errors/*"
+      ],
+      "@interfaces/*": [
+        "interfaces/*"
+      ],
     },
     "declaration": true,
     "importHelpers": true,


### PR DESCRIPTION
Hello!

Since I hadn't gotten feedback on [#2269](https://github.com/asyncapi/cli/issues/2269) yet, I've opened the pr to showcase the startup speed improvements, along with a couple of quick build speed optimizations I found while working on it.

### What's in this PR:

1. **CLI Startup Speed (Lazy Loading)**
   - Converted the top-level `@asyncapi/parser` import in `src/apps/cli/internal/base.ts` to `import type` and added a lazy getter/loader. Now, running basic commands doesn't parse `@asyncapi/parser` right away.
   - Deferred loading `ValidationService`, `ValidationStatus`, and `ConversionService` in `validate.ts` and `convert.ts` until `run()` or diagnostic handlers execute.

2. **Local Build Speed (`tsc --incremental`)**
   - Added `"incremental": true` and `"tsBuildInfoFile": "./.tsbuildinfo"` to `tsconfig.json` (and added `.tsbuildinfo` to `.gitignore`). This caches AST metadata so `tsc` doesn't re-compile all ~200 files from scratch on minor edits.

3. **Skipping Example ZIP Downloads on Build**
   - Updated `scripts/fetch-asyncapi-example.js` to check if `assets/examples/examples.json` already exists locally before fetching the 2MB zip from GitHub. I also added a `FORCE_FETCH_EXAMPLES=true` environment flag in case anyone wants to force a fresh download.

---

### Benchmarks (Tested on my machine)

- **Local Build (`npm run build`):** Dropped from **~19.75s** down to **~6.15s** (saving ~13.6 seconds per build).
- **CLI Startup (`time ./bin/run_bin config`):** Dropped from **~2.37s** down to **~1.76s**.
- **Test Suite:** All **382 tests passing** cleanly.

---

### Question for Maintainers

Does skipping the spec example download when `examples.json` already exists locally look okay to you, or would you prefer a different flag/approach for fetching examples during builds?
