### PR TITLE
docs: fix All Contributors specification link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ We love your input! We want to make contributing to this project as easy and tra
 
 ## Contribution recogniton
 
-We use [All Contributors](https://allcontributors.org/docs/en/specification) specification to handle recognitions. For more details read [this](https://www.asyncapi.com/docs/community/010-contribution-guidelines/recognize-contributors#main-content) document.
+We use [All Contributors](https://allcontributors.org/en/reference/specification/) specification to handle recognitions. For more details read [this](https://www.asyncapi.com/docs/community/010-contribution-guidelines/recognize-contributors#main-content) document.
 
 
 


### PR DESCRIPTION
### Description

Updates the outdated All Contributors specification URL in `CONTRIBUTING.md` to the current documentation path.

The previous `/docs/en/specification` URL returns 404, while the current specification is available under `/en/reference/specification/`.

### Validation

* Confirmed the old URL returns 404
* Confirmed the new URL is reachable
* `git diff --check` passes
* Documentation-only change

> Note: No separate issue was created for this change, as it is a really obvious documentation error (broken link), which the repository's CONTRIBUTING.md exempts from the "open an issue first" rule.
