### PR TITLE
fix: pack the NOTICE file

### DIFF
--- a/.changeset/pack-notice-file.md
+++ b/.changeset/pack-notice-file.md
@@ -1,0 +1,6 @@
+---
+"@asyncapi/cli": patch
+---
+
+Pack the `NOTICE` file. npm always includes `README` and `LICENSE` from the package root regardless of
+`files`, but `NOTICE` needs an explicit entry, so it had never reached the published tarball.

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "/assets",
     "/scripts",
     "/npm-shrinkwrap.json",
+    "/NOTICE",
     "/openapi.yaml",
     "/oclif.manifest.json"
   ],


### PR DESCRIPTION
## Description

The repository has a `NOTICE` file at its root, but it has never reached the published package.

`npm` always packs `README` and `LICENSE` from the package root whatever `files` says, which is why
those two ship even though `files` names neither. `NOTICE` is not on that automatic list, so it needs an
explicit entry - and it does not have one.

### Evidence from the published artifact

`@asyncapi/cli@6.0.2` packs 267 entries. Its root level is:

```
$ curl -sLO https://registry.npmjs.org/@asyncapi/cli/-/cli-6.0.2.tgz
$ tar tzf cli-6.0.2.tgz | grep -E "^package/[^/]+$"
package/LICENSE
package/oclif.manifest.json
package/package.json
package/README.md
package/openapi.yaml
```

No `NOTICE`.

### Why it matters

Apache-2.0 section 4(d) puts the obligation on whoever redistributes the work: if the distribution
includes a `NOTICE`, the attribution notices in it have to be carried along. Anyone repackaging
`@asyncapi/cli` - a Docker image, a vendored bundle, a downstream CLI - only ever receives the npm
tarball, so today they have no way to comply. Shipping the file is what makes that possible.

## Changes

One line: `"/NOTICE"` added to the `files` array. No behaviour change, no new dependency, nothing else
touched.

### Verifying

```
npm pack --dry-run
```

`NOTICE` now appears in the pack listing.