### PR TITLE
fix(logger): prevent EEXIST race condition in parallel environment

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,7 +5,7 @@ import winston from 'winston';
 
 const logDir: string = path.join(__dirname, config.has('log.dir') ? config.get('log.dir') : 'logs');
 if (!fs.existsSync(logDir)) {
-  fs.mkdirSync(logDir);
+  fs.mkdirSync(logDir, { recursive: true });
 }
 
 /*


### PR DESCRIPTION
Resolves [#2293 ](https://github.com/asyncapi/cli/issues/2293)

## Problem
When multiple CLI instances run concurrently in fresh environments (e.g. parallel builds in Docker), `logger.ts` can
crash with `EEXIST: file already exists, mkdir .../logs` if two processes try to create the `logs/` directory at the
exact same moment.

## Solution
Added `{ recursive: true }` to `fs.mkdirSync` in `src/utils/logger.ts` to make directory creation idempotent (like
`mkdir -p`) and prevent race conditions.

Tested with 50 rounds of 8 concurrent processes in Docker and verified all unit tests pass (`npm run cli:test`).